### PR TITLE
[Utf8Array] IsEmptyプロパティを追加

### DIFF
--- a/Source/Utf8Utility/Utf8Array.cs
+++ b/Source/Utf8Utility/Utf8Array.cs
@@ -136,7 +136,7 @@ public readonly partial struct Utf8Array : IEquatable<Utf8Array>,
     [SuppressMessage("Style", "IDE0075:条件式を簡略化する", Justification = "最適化のため")]
     public bool IsEmpty
     {
-        // インライン化された場合の最適化のため、三項演算子でtrue/falseとの比較を行う。
+        // インライン化された場合の最適化のため、三項演算子でtrue/falseを返す。
         // https://github.com/dotnet/runtime/issues/4207
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         get => (_value is null || _value.Length == 0) ? true : false;

--- a/Source/Utf8Utility/Utf8Array.cs
+++ b/Source/Utf8Utility/Utf8Array.cs
@@ -1,9 +1,9 @@
-﻿using System.Runtime.CompilerServices;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using System.Text;
 using Microsoft.Toolkit.HighPerformance;
 #if NET6_0_OR_GREATER
 using System.Buffers;
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using System.Text.Unicode;
 #else
@@ -127,6 +127,22 @@ public readonly partial struct Utf8Array : IEquatable<Utf8Array>,
     public int Length => _value.Length;
 
     /// <summary>
+    /// UTF-8配列が空かどうかを判定します。
+    /// </summary>
+    /// <returns>
+    /// UTF-8配列が空の場合は<see langword="true"/>、
+    /// それ以外は<see langword="false"/>。
+    /// </returns>
+    [SuppressMessage("Style", "IDE0075:条件式を簡略化する", Justification = "最適化のため")]
+    public bool IsEmpty
+    {
+        // インライン化された場合の最適化のため、三項演算子でtrue/falseとの比較を行う。
+        // https://github.com/dotnet/runtime/issues/4207
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => (_value is null || _value.Length == 0) ? true : false;
+    }
+
+    /// <summary>
     /// <see cref="Utf8Array"/>構造体の新しいインスタンスを取得します。
     /// </summary>
     /// <param name="bytes">UTF-8でエンコードされた<see cref="byte"/>配列</param>
@@ -159,16 +175,6 @@ public readonly partial struct Utf8Array : IEquatable<Utf8Array>,
     /// 同じ場合は<see langword="false"/>。
     /// </returns>
     public static bool operator !=(Utf8Array left, Utf8Array right) => !(left == right);
-
-    /// <summary>
-    /// UTF-8配列が空かどうかを判定します。
-    /// </summary>
-    /// <returns>
-    /// UTF-8配列が空の場合は<see langword="true"/>、
-    /// それ以外は<see langword="false"/>。
-    /// </returns>
-    // [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public bool IsEmpty => this == Empty;
 
     /// <inheritdoc/>
     public override bool Equals(object? obj)

--- a/Source/Utf8Utility/Utf8Array.cs
+++ b/Source/Utf8Utility/Utf8Array.cs
@@ -160,6 +160,16 @@ public readonly partial struct Utf8Array : IEquatable<Utf8Array>,
     /// </returns>
     public static bool operator !=(Utf8Array left, Utf8Array right) => !(left == right);
 
+    /// <summary>
+    /// UTF-8配列が空かどうかを判定します。
+    /// </summary>
+    /// <returns>
+    /// UTF-8配列が空の場合は<see langword="true"/>、
+    /// それ以外は<see langword="false"/>。
+    /// </returns>
+    // [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool IsEmpty => this == Empty;
+
     /// <inheritdoc/>
     public override bool Equals(object? obj)
         => obj is Utf8Array x && Equals(x);

--- a/Tests/Utf8Utility.Tests/Utf8ArrayIsEmptyTest.cs
+++ b/Tests/Utf8Utility.Tests/Utf8ArrayIsEmptyTest.cs
@@ -1,0 +1,31 @@
+﻿using FluentAssertions;
+using Xunit;
+
+namespace Utf8Utility.Tests;
+
+public sealed class Utf8ArrayIsEmptyTest
+{
+    [Fact]
+    public void 空文字列同士_trueを返す()
+    {
+        var values = new[]
+        {
+            Utf8Array.Empty,
+            new(Array.Empty<byte>()),
+            new(string.Empty),
+            new(ReadOnlySpan<byte>.Empty),
+            new(ReadOnlySpan<char>.Empty)
+        };
+
+        foreach (var value in values)
+        {
+            value.IsEmpty.Should().BeTrue();
+        }
+    }
+
+    [Theory]
+    [InlineData("a")]
+    [InlineData(" ")]
+    public void 空文字列以外_falseを返す(string value)
+        => new Utf8Array(value).IsEmpty.Should().BeFalse();
+}


### PR DESCRIPTION
[SharpLab](https://sharplab.io/#v2:EYLgxg9gTgpgtADwGwBYA0AXEBDAzgWwB8ABAJgEYBYAKGIAYACY8gOgCUBXAOwwEt8YLAMIR8AB14AbGFADKMgG68wMXAG4aNYgGYGsbABMIXSQE8GY7FD7ZJDXBigcwGBgFUMAMwAcAQShQ2OYgDACSAKIAjhzYGNjA0gA8Hj7+gaYAfDQA3jQM+XowhsZmDMCmGDAA2gC6DAD6CrYcMBrUBQx5BTruXn4BQQAU5ZW1ZRWqAJRd+bntHQW8ngzDE7gMvOtcHJKSk3MLhwwAKgAWUBAA7v4A5hwCPAByO5LhCCpifMaDXNgCEJ5VpVcJNJm0jgwAL6aeaHRrNGAMAC842B4IK0NhnSxVQAsjAMKcIAZQuJJIN8YTiaSxJIAPKfXjGXAsXw3G6wXC4XgKGChEy8LiCm6TGozJi6YAQCB2UK4cLiDCmciDSbIjINJqSFobLYvBiEQgMQmbZEohWfUzo/LivEEokkskU+3UskMr5cFlsjmqbm8/mSQXC0XinpSmVheWK0ykVXqzUI3UMba7A1G+HaxFIlFpIIsC1KxIjGAZVXW7EdO1Ux2053Vmn0xnM1nszl+vkCoVcEVirFh6WyqOW7RxpEajM600puyGhOZlgAGRg3cJZoYdHLtspDobdZ3bqbnpbPq5PI7ga7PdDkoHkYLphQo41gwniKn+tnr8Xy5uq+z67VAB+Y0nEREJPFsXBWnFLcXRrclt1dWl3SZI9vTbM8AyDbsQz7G8Izle8AFYnxWV8k2yBglxXU4Qg1RhISAhgIMkKCGBCRwWk3HFEPgvckMbD0vVbX1MM7YNew6HpmCQMpbwgMQZFiaAzUGFJ+nSBhpE8DA0F6VIBnMKBeBuU4MDVMctJgHT82iSDBmM0zzO4yteN3NyDyE48MP9cScMk7pdBkuSIwUpSMBUgBCJE1L6XNzG03T9I0oI9BMsyLI1SLBkStdHIylyCirfdaw85DD2Ek92ywy9cKk/C7CiGJWNigzNIgQkZEyucWlZXBZEsLhVRYeRomXFQmtsQYOtOGQWFfME8mvJhyFk9T4oYe9xQOI5ioE/j4JQ5t0NE3yLwk8UOhuAl4zcT1sE8GAhH0SpBni/NoyLCZS1BctMQ6ZbguIFATnOK5bnuZcMGeXY3g+D1BmYRhLECfBHj+GBpixDpLMJC5LmTGACYhh5oZeOGYEPQYUb+dGBEWrFxUFSooF+OxgvWwz3Hux7nqKV7izGYsQW2y6Ck5zStR1FEDGs7AdgwcsOju3AHsEXxcDYazBilwQFuRVFVDaMX8mIAB2Bhdb+mhMS0ILSBOHJAdWjYeAYXwVQl1KrHSbqfbzQjoxVJjyHYhhSHLaSXeZ93Yy98x/dMP3DJYQPLVjEOw4j53ZJj3wR3jhhE+T9JU6HJUR0zkJs7wlbc7d3xH0L4v40Tsv70fKvw8joLo4bkjm8MkuA/L0wSK7mvISAA==)

```csharp
using System;
using System.Runtime.CompilerServices;

public readonly partial struct Utf8Array : IEquatable<Utf8Array>
{
    readonly byte[] _value;
    
    public Utf8Array(byte[] bytes)
    {
        if (bytes is null){
            ThrowArgumentNullException(nameof(bytes));
        }

        _value = bytes;
    }
    
    [MethodImpl(MethodImplOptions.AggressiveInlining)]
    public bool IsEmpty1() => _value is null || this == Empty;
    
    [MethodImpl(MethodImplOptions.AggressiveInlining)]
    public bool IsEmpty2() => _value is null || _value == Array.Empty<byte>();
    
    [MethodImpl(MethodImplOptions.AggressiveInlining)]
    public bool IsEmpty3() => _value is null || _value.Length == 0;
    
    [MethodImpl(MethodImplOptions.AggressiveInlining)]
    public bool IsEmpty4() => (_value is null || _value.Length == 0) ? true : false;
    
    [MethodImpl(MethodImplOptions.AggressiveInlining)]
    public bool IsEmpty5() => (_value is { Length: > 0 }) ? false : true;
    
    [MethodImpl(MethodImplOptions.AggressiveInlining)]
    public static bool operator ==(Utf8Array left, Utf8Array right) => left.Equals(right);
    
    [MethodImpl(MethodImplOptions.AggressiveInlining)]
    public static bool operator !=(Utf8Array left, Utf8Array right) => !(left == right);
    
    [MethodImpl(MethodImplOptions.AggressiveInlining)]
    public bool Equals(Utf8Array other) => _value.AsSpan().SequenceEqual(other._value);
 
    public static Utf8Array Empty
    {
        [MethodImpl(MethodImplOptions.AggressiveInlining)]
        get => UnsafeCreate(Array.Empty<byte>());
    }
    
    public static void ThrowArgumentNullException(string paramName)
        => throw new ArgumentNullException(paramName);
    
    internal static Utf8Array UnsafeCreate(byte[] bytes)
    {
        Utf8Array value = default;
        Unsafe.AsRef(value._value) = bytes;

        return value;
    }
}

public class T
{
    public static int A1(Utf8Array array) => array.IsEmpty1() ? 1 : 2;
    public static int A2(Utf8Array array) => array.IsEmpty2() ? 1 : 2;
    public static int A3(Utf8Array array) => array.IsEmpty3() ? 1 : 2;
    public static int A4(Utf8Array array) => array.IsEmpty4() ? 1 : 2;
    public static int A5(Utf8Array array) => array.IsEmpty5() ? 1 : 2;
}
```

```asm
; Core CLR 5.0.921.35908 on amd64

Utf8Array..ctor(Byte[])
    L0000: sub rsp, 0x28
    L0004: test rdx, rdx
    L0007: je short L0014
    L0009: call 0x00007ffcef24a050
    L000e: nop
    L000f: add rsp, 0x28
    L0013: ret
    L0014: mov rcx, 0x19bd91c95b8
    L001e: mov rcx, [rcx]
    L0021: call 0x00007ffc9a5000d0
    L0026: int3

Utf8Array.IsEmpty1()
    L0000: sub rsp, 0x28
    L0004: mov r8, [rcx]
    L0007: test r8, r8
    L000a: je short L005d
    L000c: mov rcx, 0x19bd91c2d48
    L0016: mov rcx, [rcx]
    L0019: test r8, r8
    L001c: jne short L0024
    L001e: xor edx, edx
    L0020: xor eax, eax
    L0022: jmp short L002c
    L0024: lea rdx, [r8+0x10]
    L0028: mov eax, [r8+8]
    L002c: test rcx, rcx
    L002f: jne short L0039
    L0031: xor r8d, r8d
    L0034: xor r9d, r9d
    L0037: jmp short L0041
    L0039: lea r8, [rcx+0x10]
    L003d: mov r9d, [rcx+8]
    L0041: mov rcx, rdx
    L0044: mov rdx, r8
    L0047: cmp eax, r9d
    L004a: jne short L0056
    L004c: movsxd r8, eax
    L004f: call 0x00007ffc8f6b8530
    L0054: jmp short L0058
    L0056: xor eax, eax
    L0058: add rsp, 0x28
    L005c: ret
    L005d: mov eax, 1
    L0062: add rsp, 0x28
    L0066: ret

Utf8Array.IsEmpty2()
    L0000: mov rax, [rcx]
    L0003: test rax, rax
    L0006: je short L001c
    L0008: mov rdx, 0x19bd91c2d48
    L0012: cmp rax, [rdx]
    L0015: sete al
    L0018: movzx eax, al
    L001b: ret
    L001c: mov eax, 1
    L0021: ret

Utf8Array.IsEmpty3()
    L0000: mov rax, [rcx]
    L0003: test rax, rax
    L0006: je short L0013
    L0008: cmp dword ptr [rax+8], 0
    L000c: sete al
    L000f: movzx eax, al
    L0012: ret
    L0013: mov eax, 1
    L0018: ret

Utf8Array.IsEmpty4()
    L0000: mov rax, [rcx]
    L0003: test rax, rax
    L0006: je short L0011
    L0008: cmp dword ptr [rax+8], 0
    L000c: je short L0011
    L000e: xor eax, eax
    L0010: ret
    L0011: mov eax, 1
    L0016: ret

Utf8Array.IsEmpty5()
    L0000: sub rsp, 0x28
    L0004: mov rax, [rcx]
    L0007: test rax, rax
    L000a: je short L0017
    L000c: mov eax, [rax+8]
    L000f: test eax, eax
    L0011: jl short L0028
    L0013: test eax, eax
    L0015: jg short L0021
    L0017: mov eax, 1
    L001c: add rsp, 0x28
    L0020: ret
    L0021: xor eax, eax
    L0023: add rsp, 0x28
    L0027: ret
    L0028: call 0x00007ffcef389e10
    L002d: int3

Utf8Array.op_Equality(Utf8Array, Utf8Array)
    L0000: sub rsp, 0x28
    L0004: test rcx, rcx
    L0007: jne short L0010
    L0009: xor ecx, ecx
    L000b: xor r8d, r8d
    L000e: jmp short L001a
    L0010: lea r8, [rcx+0x10]
    L0014: mov ecx, [rcx+8]
    L0017: xchg r8, rcx
    L001a: test rdx, rdx
    L001d: jne short L0025
    L001f: xor edx, edx
    L0021: xor eax, eax
    L0023: jmp short L002f
    L0025: lea rax, [rdx+0x10]
    L0029: mov edx, [rdx+8]
    L002c: xchg rdx, rax
    L002f: cmp r8d, eax
    L0032: jne short L003e
    L0034: movsxd r8, r8d
    L0037: call 0x00007ffc8f6b8530
    L003c: jmp short L0040
    L003e: xor eax, eax
    L0040: add rsp, 0x28
    L0044: ret

Utf8Array.op_Inequality(Utf8Array, Utf8Array)
    L0000: sub rsp, 0x28
    L0004: test rcx, rcx
    L0007: jne short L0010
    L0009: xor ecx, ecx
    L000b: xor r8d, r8d
    L000e: jmp short L001a
    L0010: lea r8, [rcx+0x10]
    L0014: mov ecx, [rcx+8]
    L0017: xchg r8, rcx
    L001a: test rdx, rdx
    L001d: jne short L0025
    L001f: xor edx, edx
    L0021: xor eax, eax
    L0023: jmp short L002f
    L0025: lea rax, [rdx+0x10]
    L0029: mov edx, [rdx+8]
    L002c: xchg rdx, rax
    L002f: cmp r8d, eax
    L0032: jne short L003e
    L0034: movsxd r8, r8d
    L0037: call 0x00007ffc8f6b8530
    L003c: jmp short L0040
    L003e: xor eax, eax
    L0040: test eax, eax
    L0042: sete al
    L0045: movzx eax, al
    L0048: add rsp, 0x28
    L004c: ret

Utf8Array.Equals(Utf8Array)
    L0000: sub rsp, 0x28
    L0004: mov r8, [rcx]
    L0007: test r8, r8
    L000a: jne short L0012
    L000c: xor ecx, ecx
    L000e: xor eax, eax
    L0010: jmp short L001a
    L0012: lea rcx, [r8+0x10]
    L0016: mov eax, [r8+8]
    L001a: test rdx, rdx
    L001d: jne short L0026
    L001f: xor edx, edx
    L0021: xor r8d, r8d
    L0024: jmp short L0030
    L0026: lea r8, [rdx+0x10]
    L002a: mov edx, [rdx+8]
    L002d: xchg r8, rdx
    L0030: cmp eax, r8d
    L0033: jne short L003f
    L0035: movsxd r8, eax
    L0038: call 0x00007ffc8f6b8530
    L003d: jmp short L0041
    L003f: xor eax, eax
    L0041: add rsp, 0x28
    L0045: ret

Utf8Array.get_Empty()
    L0000: mov rax, 0x19bd91c2d48
    L000a: mov rax, [rax]
    L000d: ret

Utf8Array.ThrowArgumentNullException(System.String)
    L0000: push rdi
    L0001: push rsi
    L0002: sub rsp, 0x28
    L0006: mov rsi, rcx
    L0009: mov rcx, 0x7ffc8f753640
    L0013: call 0x00007ffcef24a6b0
    L0018: mov rdi, rax
    L001b: mov rcx, rdi
    L001e: mov rdx, rsi
    L0021: call 0x00007ffc8f6b7e50
    L0026: mov rcx, rdi
    L0029: call 0x00007ffcef1ecf50
    L002e: int3

Utf8Array.UnsafeCreate(Byte[])
    L0000: mov rax, rcx
    L0003: ret

T..ctor()
    L0000: ret

T.A1(Utf8Array)
    L0000: sub rsp, 0x28
    L0004: test rcx, rcx
    L0007: je short L0056
    L0009: mov r8, 0x19bd91c2d48
    L0013: mov r8, [r8]
    L0016: lea rdx, [rcx+0x10]
    L001a: mov ecx, [rcx+8]
    L001d: test r8, r8
    L0020: jne short L0029
    L0022: xor eax, eax
    L0024: xor r9d, r9d
    L0027: jmp short L0031
    L0029: lea rax, [r8+0x10]
    L002d: mov r9d, [r8+8]
    L0031: cmp ecx, r9d
    L0034: jne short L0046
    L0036: movsxd r8, ecx
    L0039: mov rcx, rdx
    L003c: mov rdx, rax
    L003f: call 0x00007ffc8f6b8530
    L0044: jmp short L0048
    L0046: xor eax, eax
    L0048: test eax, eax
    L004a: jne short L0056
    L004c: mov eax, 2
    L0051: add rsp, 0x28
    L0055: ret
    L0056: mov eax, 1
    L005b: add rsp, 0x28
    L005f: ret

T.A2(Utf8Array)
    L0000: test rcx, rcx
    L0003: je short L0022
    L0005: mov rax, 0x19bd91c2d48
    L000f: cmp rcx, [rax]
    L0012: sete al
    L0015: movzx eax, al
    L0018: test eax, eax
    L001a: jne short L0022
    L001c: mov eax, 2
    L0021: ret
    L0022: mov eax, 1
    L0027: ret

T.A3(Utf8Array)
    L0000: test rcx, rcx
    L0003: je short L0019
    L0005: cmp dword ptr [rcx+8], 0
    L0009: sete al
    L000c: movzx eax, al
    L000f: test eax, eax
    L0011: jne short L0019
    L0013: mov eax, 2
    L0018: ret
    L0019: mov eax, 1
    L001e: ret

T.A4(Utf8Array)
    L0000: test rcx, rcx
    L0003: je short L0011
    L0005: cmp dword ptr [rcx+8], 0
    L0009: je short L0011
    L000b: mov eax, 2
    L0010: ret
    L0011: mov eax, 1
    L0016: ret

T.A5(Utf8Array)
    L0000: sub rsp, 0x28
    L0004: test rcx, rcx
    L0007: je short L0014
    L0009: mov eax, [rcx+8]
    L000c: test eax, eax
    L000e: jl short L0035
    L0010: test eax, eax
    L0012: jg short L001b
    L0014: mov eax, 1
    L0019: jmp short L001d
    L001b: xor eax, eax
    L001d: test eax, eax
    L001f: jne short L002b
    L0021: mov eax, 2
    L0026: add rsp, 0x28
    L002a: ret
    L002b: mov eax, 1
    L0030: add rsp, 0x28
    L0034: ret
    L0035: call 0x00007ffcef389e10
    L003a: int3
```