### PR TITLE
[Utf8Array] AsSpanメソッドで初期インデックスが指定されている場合、範囲外になっていた問題を修正

### DIFF
--- a/Source/Utf8Utility/Utf8Array.cs
+++ b/Source/Utf8Utility/Utf8Array.cs
@@ -231,10 +231,11 @@ public readonly partial struct Utf8Array : IEquatable<Utf8Array>,
     {
         // 引数の検証をスキップするために、手動でReadOnlySpanを作成する。
 #if NET6_0_OR_GREATER
+        var length = _value.Length - start;
         ref var valueStart = ref DangerousGetReferenceAt(start);
-        return MemoryMarshal.CreateReadOnlySpan(ref valueStart, _value.Length);
+        return MemoryMarshal.CreateReadOnlySpan(ref valueStart, length);
 #else
-        var span = new ReadOnlySpan<byte>(_value, start, _value.Length);
+        var span = new ReadOnlySpan<byte>(_value, start, _value.Length - start);
         return span;
 #endif
     }

--- a/Tests/Utf8Utility.Tests/Utf8ArrayAsSpanTest.cs
+++ b/Tests/Utf8Utility.Tests/Utf8ArrayAsSpanTest.cs
@@ -1,0 +1,28 @@
+﻿using System.Text;
+using FluentAssertions;
+using Xunit;
+
+namespace Utf8Utility.Tests;
+
+public sealed class Utf8ArrayAsSpanTest
+{
+    [Theory]
+    [InlineData("abc")]
+    public void 初期インデックス0(string value)
+    {
+        var span = new Utf8Array(value).AsSpan();
+        var array = Encoding.UTF8.GetBytes(value);
+
+        span.SequenceEqual(array).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("abcdef")]
+    public void 初期インデックス3(string value)
+    {
+        var span = new Utf8Array(value).AsSpan(3);
+        var array = Encoding.UTF8.GetBytes(value).AsSpan(3);
+
+        span.SequenceEqual(array).Should().BeTrue();
+    }
+}


### PR DESCRIPTION
[SharpLab](https://sharplab.io/#v2:EYLgxg9gTgpgtADwGwBYA0AXEBDAzgWwB8ABAJgEYBYAKGIAYACY8gOgCUBXAOwwEt8YLAMIR8AB14AbGFADKMgG68wMXAG4a9Jq049+ggJI8ZEMfKhKV6mpoDMTUgyEMA3jQYeGsbABMIXSQBPBmBAjBgAbQBdBgB9BA1qTwZ3T2J7IQAKUPDohgQASgYAXgA+OIQS/MTk1I90hjYYXwB5AMDZMWwuAB4cmHKAIXJM3h4GXAxsKAwisoqWAEFcTu7MyenZms86pnsm1vbV3v6h0lHxjZmC3bck5M9YADMGBWn83CrnhgBVLlxsE9BIsfD5Mt8ALIwfDQQIQ6a4AAW2EkLAA4jAMIsoFBsIEACLYKZNIGwLgqTLxApoBiZLhjWaZDgMgpXLa7ZLEADsDChMKgcIRyNRQm84QOPjaQWO4JgLwQuBp8RYABkYFwAOYYREMOATKbXbYeAC+u12DQlUo6XROYQGDEGtguGH1mxu9w8dwenjeUAY0k12qqyrVgZ1erZRoe319Hy+ct+/0BwNBspefNh8KgSJR6Mx2NxBKJ2BJMnVFKpNLpLKZLLZBSjnJ5GYFWZzIrFMEtRxtaY+NIDWsRDd2po9KXHFuakp73T6dqGKGdruutw5PveuBtVS4MAA7o1p1bjvPwqVKQgaWylQhVeqh7qV+zx02Jjao2PapP9kfZ7azw6ACsy71muL4bn6g5BsUCyhg+EYGhgjYQW+3Q7vuh6HNKNqngMF5XohA73tqI7gfUPJbt0H40MaQA===)

```cs
using System;
using System.Runtime.CompilerServices;
using System.Runtime.InteropServices;

public class C {
    readonly byte[] _x;
    
    public C(byte[] x) => _x = x;
    
    public ReadOnlySpan<byte> B1(int start) => _x.AsSpan(start);
    
    public ReadOnlySpan<byte> B2(int start)
    {
        ref var xs = ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(_x), (nint)(uint)start);
        return MemoryMarshal.CreateReadOnlySpan(ref xs, _x.Length - start);
    }
    
    public ReadOnlySpan<byte> B3(int start)
    {
        var length = _x.Length - start;
        ref var xs = ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(_x), (nint)(uint)start);
        return MemoryMarshal.CreateReadOnlySpan(ref xs, length);
    }
    
    public ReadOnlySpan<byte> B4(int start)
    {
        var span = new ReadOnlySpan<byte>(_x, start, _x.Length - start);
        return span;
    }
    
    public ReadOnlySpan<byte> B5(int start)
    {
        var length = _x.Length - start;
        var span = new ReadOnlySpan<byte>(_x, start, length);
        return span;
    }
}
```
```asm
C.B1(Int32)
    L0000: sub rsp, 0x28
    L0004: mov rax, [rcx+8]
    L0008: test rax, rax
    L000b: jne short L0019
    L000d: test r8d, r8d
    L0010: jne short L003e
    L0012: xor ecx, ecx
    L0014: xor r9d, r9d
    L0017: jmp short L002f
    L0019: mov r9d, [rax+8]
    L001d: cmp r9d, r8d
    L0020: jb short L003e
    L0022: add rax, 0x10
    L0026: sub r9d, r8d
    L0029: movsxd rcx, r8d
    L002c: add rcx, rax
    L002f: mov [rdx], rcx
    L0032: mov [rdx+8], r9d
    L0036: mov rax, rdx
    L0039: add rsp, 0x28
    L003d: ret
    L003e: call 0x00007ffc8f6d5ce8
    L0043: int3

C.B2(Int32)
    L0000: mov rax, [rcx+8]
    L0004: mov rcx, rax
    L0007: cmp [rcx], ecx
    L0009: add rcx, 0x10
    L000d: mov eax, [rax+8]
    L0010: sub eax, r8d
    L0013: mov r8d, r8d
    L0016: add rcx, r8
    L0019: mov [rdx], rcx
    L001c: mov [rdx+8], eax
    L001f: mov rax, rdx
    L0022: ret

C.B3(Int32)
    L0000: mov rax, [rcx+8]
    L0004: mov ecx, [rax+8]
    L0007: sub ecx, r8d
    L000a: cmp [rax], eax
    L000c: add rax, 0x10
    L0010: mov r8d, r8d
    L0013: add rax, r8
    L0016: mov [rdx], rax
    L0019: mov [rdx+8], ecx
    L001c: mov rax, rdx
    L001f: ret

C.B4(Int32)
    L0000: sub rsp, 0x28
    L0004: mov rax, [rcx+8]
    L0008: mov rcx, rax
    L000b: mov eax, [rax+8]
    L000e: sub eax, r8d
    L0011: mov r9d, r8d
    L0014: mov r10d, eax
    L0017: add r9, r10
    L001a: mov r10d, [rcx+8]
    L001e: cmp r9, r10
    L0021: ja short L003b
    L0023: add rcx, 0x10
    L0027: movsxd r8, r8d
    L002a: add rcx, r8
    L002d: mov [rdx], rcx
    L0030: mov [rdx+8], eax
    L0033: mov rax, rdx
    L0036: add rsp, 0x28
    L003a: ret
    L003b: call 0x00007ffc8f6d5ce8
    L0040: int3

C.B5(Int32)
    L0000: sub rsp, 0x28
    L0004: mov rax, [rcx+8]
    L0008: mov ecx, [rax+8]
    L000b: sub ecx, r8d
    L000e: test rax, rax
    L0011: jne short L0020
    L0013: or r8d, ecx
    L0016: jne short L004e
    L0018: xor r9d, r9d
    L001b: xor r10d, r10d
    L001e: jmp short L003f
    L0020: mov r9d, r8d
    L0023: mov r10d, ecx
    L0026: add r9, r10
    L0029: mov r10d, [rax+8]
    L002d: cmp r9, r10
    L0030: ja short L004e
    L0032: add rax, 0x10
    L0036: movsxd r9, r8d
    L0039: add r9, rax
    L003c: mov r10d, ecx
    L003f: mov [rdx], r9
    L0042: mov [rdx+8], r10d
    L0046: mov rax, rdx
    L0049: add rsp, 0x28
    L004d: ret
    L004e: call 0x00007ffc8f6d5ce8
    L0053: int3
```