### PR TITLE
Unsafe.Addを使っていた箇所の一部をUnsafe.AddByteOffsetに書き換え

### DIFF
--- a/Source/Utf8Utility/Text/AsciiUtility.cs
+++ b/Source/Utf8Utility/Text/AsciiUtility.cs
@@ -40,6 +40,6 @@ public static class AsciiUtility
     internal static bool IsWhiteSpace(byte value)
     {
         ref var table = ref MemoryMarshal.GetReference(AsciiCharInfo);
-        return (Unsafe.Add(ref table, (nint)value) & IsWhiteSpaceFlag) != 0;
+        return (Unsafe.AddByteOffset(ref table, (nint)value) & IsWhiteSpaceFlag) != 0;
     }
 }

--- a/Source/Utf8Utility/Text/UnicodeUtility.cs
+++ b/Source/Utf8Utility/Text/UnicodeUtility.cs
@@ -37,7 +37,7 @@ public static class UnicodeUtility
         };
 
         ref var table = ref MemoryMarshal.GetReference(trailingBytesForUTF8);
-        return Unsafe.Add(ref table, (nint)value);
+        return Unsafe.AddByteOffset(ref table, (nint)value);
     }
 
     /// <summary>


### PR DESCRIPTION
- Unsafe.AddByteOffsetの方が処理が明確
- nintへのキャスト忘れ防止（Unsafe.AddByteOffsetにはintオーバーロードがない）
- 定数は引き続きUnsafe.Addを使う（キャスト面倒なため）