### PR TITLE
[Utf8Array] GetLengthを最適化

### DIFF
--- a/Source/Utf8Utility.Benchmarks/BenchmarkConfig.cs
+++ b/Source/Utf8Utility.Benchmarks/BenchmarkConfig.cs
@@ -1,0 +1,34 @@
+﻿using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Environments;
+using BenchmarkDotNet.Exporters;
+using BenchmarkDotNet.Jobs;
+
+namespace Utf8Utility.Benchmarks;
+
+public sealed class BenchmarkConfig : ManualConfig
+{
+    public BenchmarkConfig()
+    {
+        AddExporter(MarkdownExporter.GitHub);
+        AddLogicalGroupRules(BenchmarkLogicalGroupRule.ByCategory);
+        AddColumn(CategoriesColumn.Default);
+        AddDiagnoser(MemoryDiagnoser.Default);
+
+        AddJob(Job.Default.WithRuntime(CoreRuntime.Core60)
+            .WithId("Default"));
+
+        AddJob(Job.Default.WithRuntime(CoreRuntime.Core60)
+            .WithEnvironmentVariables(
+                new EnvironmentVariable("COMPlus_ReadyToRun", "0"),
+                new EnvironmentVariable("COMPlus_TC_QuickJitForLoops", "1"),
+                new EnvironmentVariable("COMPlus_TieredPGO", "1"))
+            .WithId("NoReadyToRun, QuickJitForLoops, TieredPGO"));
+
+        AddJob(Job.Default.WithRuntime(CoreRuntime.Core60)
+            .WithEnvironmentVariables(
+                new EnvironmentVariable("COMPlus_EnableHWIntrinsic", "0"))
+            .WithId("DisableHWIntrinsic"));
+    }
+}

--- a/Source/Utf8Utility.Benchmarks/BenchmarkConfig.cs
+++ b/Source/Utf8Utility.Benchmarks/BenchmarkConfig.cs
@@ -21,13 +21,6 @@ public sealed class BenchmarkConfig : ManualConfig
 
         AddJob(Job.Default.WithRuntime(CoreRuntime.Core60)
             .WithEnvironmentVariables(
-                new EnvironmentVariable("COMPlus_ReadyToRun", "0"),
-                new EnvironmentVariable("COMPlus_TC_QuickJitForLoops", "1"),
-                new EnvironmentVariable("COMPlus_TieredPGO", "1"))
-            .WithId("NoReadyToRun, QuickJitForLoops, TieredPGO"));
-
-        AddJob(Job.Default.WithRuntime(CoreRuntime.Core60)
-            .WithEnvironmentVariables(
                 new EnvironmentVariable("COMPlus_EnableHWIntrinsic", "0"))
             .WithId("DisableHWIntrinsic"));
     }

--- a/Source/Utf8Utility.Benchmarks/Utf8ArrayGetLengthBenchmark.cs
+++ b/Source/Utf8Utility.Benchmarks/Utf8ArrayGetLengthBenchmark.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿using System.Numerics;
+using System.Runtime.CompilerServices;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Jobs;
 
@@ -20,18 +21,18 @@ public class Utf8ArrayGetLengthBenchmark
     public int GetLength_Loop()
     {
         var count = 0;
-        nuint i = 0;
+        nuint index = 0;
 
-        while ((int)i < _value.ByteCount)
+        while ((int)index < _value.ByteCount)
         {
-            var value = Unsafe.AddByteOffset(ref _value.DangerousGetReference(), i);
+            var value = Unsafe.AddByteOffset(ref _value.DangerousGetReference(), index);
 
             if ((value & 0xC0) != 0x80)
             {
                 count++;
             }
 
-            i++;
+            index++;
         }
 
         return count;
@@ -46,76 +47,27 @@ public class Utf8ArrayGetLengthBenchmark
         const ulong Mask = 0x8080808080808080;
 
         var count = 0;
-        nuint i = 0;
-        var length = _value.ByteCount - 8;
+        nuint index = 0;
+        var length = _value.ByteCount - sizeof(ulong);
 
-        while ((int)i <= length)
+        while ((int)index <= length)
         {
-            var value = Unsafe.As<byte, ulong>(ref Unsafe.AddByteOffset(ref _value.DangerousGetReference(), i));
+            var value = Unsafe.As<byte, ulong>(ref Unsafe.AddByteOffset(ref _value.DangerousGetReference(), index));
             var x = ((value >> 6) | (~value >> 7)) & (Mask >> 7);
-            count += System.Numerics.BitOperations.PopCount(x);
-            i += 8;
+            count += BitOperations.PopCount(x);
+            index += sizeof(ulong);
         }
 
-        while ((int)i < _value.ByteCount)
+        while ((int)index < _value.ByteCount)
         {
-            var value = Unsafe.AddByteOffset(ref _value.DangerousGetReference(), i);
+            var value = Unsafe.AddByteOffset(ref _value.DangerousGetReference(), index);
 
             if ((value & 0xC0) != 0x80)
             {
                 count++;
             }
 
-            i++;
-        }
-
-        return count;
-    }
-
-    [Benchmark]
-    public int GetLength_Long2()
-    {
-        const ulong Mask = 0x8080808080808080;
-
-        var count = 0;
-        nuint i = 0;
-        var length = _value.ByteCount - (8 * 4);
-
-        while ((int)i <= length)
-        {
-            ref var value = ref Unsafe.As<byte, ulong>(ref Unsafe.AddByteOffset(ref _value.DangerousGetReference(), i));
-            var value0 = value;
-            var value1 = Unsafe.Add(ref value, 1);
-            var value2 = Unsafe.Add(ref value, 2);
-            var value3 = Unsafe.Add(ref value, 3);
-
-            count += System.Numerics.BitOperations.PopCount(((value0 >> 6) | (~value0 >> 7)) & (Mask >> 7));
-            count += System.Numerics.BitOperations.PopCount(((value1 >> 6) | (~value1 >> 7)) & (Mask >> 7));
-            count += System.Numerics.BitOperations.PopCount(((value2 >> 6) | (~value2 >> 7)) & (Mask >> 7));
-            count += System.Numerics.BitOperations.PopCount(((value3 >> 6) | (~value3 >> 7)) & (Mask >> 7));
-            i += 8 * 4;
-        }
-
-        length = _value.ByteCount - 8;
-
-        while ((int)i <= length)
-        {
-            var value = Unsafe.As<byte, ulong>(ref Unsafe.AddByteOffset(ref _value.DangerousGetReference(), i));
-            var x = ((value >> 6) | (~value >> 7)) & (Mask >> 7);
-            count += System.Numerics.BitOperations.PopCount(x);
-            i += 8;
-        }
-
-        while ((int)i < _value.ByteCount)
-        {
-            var value = Unsafe.AddByteOffset(ref _value.DangerousGetReference(), i);
-
-            if ((value & 0xC0) != 0x80)
-            {
-                count++;
-            }
-
-            i++;
+            index++;
         }
 
         return count;

--- a/Source/Utf8Utility.Benchmarks/Utf8ArrayGetLengthBenchmark.cs
+++ b/Source/Utf8Utility.Benchmarks/Utf8ArrayGetLengthBenchmark.cs
@@ -60,6 +60,6 @@ public class Utf8ArrayGetLengthBenchmark
         return count;
     }
 
-    [Benchmark]
+    [Benchmark(Baseline = true)]
     public int GetLength_Long() => _value.GetLength();
 }

--- a/Source/Utf8Utility.Benchmarks/Utf8ArrayGetLengthBenchmark.cs
+++ b/Source/Utf8Utility.Benchmarks/Utf8ArrayGetLengthBenchmark.cs
@@ -71,4 +71,53 @@ public class Utf8ArrayGetLengthBenchmark
 
         return count;
     }
+
+    [Benchmark]
+    public int GetLength_Long2()
+    {
+        const ulong Mask = 0x8080808080808080;
+
+        var count = 0;
+        nuint i = 0;
+        var length = _value.ByteCount - (8 * 4);
+
+        while ((int)i <= length)
+        {
+            ref var value = ref Unsafe.As<byte, ulong>(ref Unsafe.AddByteOffset(ref _value.DangerousGetReference(), i));
+            var value0 = value;
+            var value1 = Unsafe.Add(ref value, 1);
+            var value2 = Unsafe.Add(ref value, 2);
+            var value3 = Unsafe.Add(ref value, 3);
+
+            count += System.Numerics.BitOperations.PopCount(((value0 >> 6) | (~value0 >> 7)) & (Mask >> 7));
+            count += System.Numerics.BitOperations.PopCount(((value1 >> 6) | (~value1 >> 7)) & (Mask >> 7));
+            count += System.Numerics.BitOperations.PopCount(((value2 >> 6) | (~value2 >> 7)) & (Mask >> 7));
+            count += System.Numerics.BitOperations.PopCount(((value3 >> 6) | (~value3 >> 7)) & (Mask >> 7));
+            i += 8 * 4;
+        }
+
+        length = _value.ByteCount - 8;
+
+        while ((int)i <= length)
+        {
+            var value = Unsafe.As<byte, ulong>(ref Unsafe.AddByteOffset(ref _value.DangerousGetReference(), i));
+            var x = ((value >> 6) | (~value >> 7)) & (Mask >> 7);
+            count += System.Numerics.BitOperations.PopCount(x);
+            i += 8;
+        }
+
+        while ((int)i < _value.ByteCount)
+        {
+            var value = Unsafe.AddByteOffset(ref _value.DangerousGetReference(), i);
+
+            if ((value & 0xC0) != 0x80)
+            {
+                count++;
+            }
+
+            i++;
+        }
+
+        return count;
+    }
 }

--- a/Source/Utf8Utility.Benchmarks/Utf8ArrayGetLengthBenchmark.cs
+++ b/Source/Utf8Utility.Benchmarks/Utf8ArrayGetLengthBenchmark.cs
@@ -1,12 +1,10 @@
 ﻿using System.Numerics;
 using System.Runtime.CompilerServices;
 using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Jobs;
 
 namespace Utf8Utility.Benchmarks;
 
-[SimpleJob(RuntimeMoniker.Net60)]
-[MemoryDiagnoser]
+[Config(typeof(BenchmarkConfig)]
 public class Utf8ArrayGetLengthBenchmark
 {
     Utf8Array _value;
@@ -47,7 +45,7 @@ public class Utf8ArrayGetLengthBenchmark
     [Benchmark]
     public int GetLength_Long()
     {
-        const ulong Mask = 0x8080808080808080;
+        const ulong Mask = 0x8080808080808080 >> 7;
 
         var count = 0;
         nuint index = 0;
@@ -56,7 +54,7 @@ public class Utf8ArrayGetLengthBenchmark
         while ((int)index <= length)
         {
             var value = Unsafe.As<byte, ulong>(ref Unsafe.AddByteOffset(ref _value.DangerousGetReference(), index));
-            var x = ((value >> 6) | (~value >> 7)) & (Mask >> 7);
+            var x = ((value >> 6) | (~value >> 7)) & Mask;
             count += BitOperations.PopCount(x);
             index += sizeof(ulong);
         }

--- a/Source/Utf8Utility.Benchmarks/Utf8ArrayGetLengthBenchmark.cs
+++ b/Source/Utf8Utility.Benchmarks/Utf8ArrayGetLengthBenchmark.cs
@@ -1,0 +1,55 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+using Utf8Utility.Benchmarks.Helpers;
+
+namespace Utf8Utility.Benchmarks;
+
+[SimpleJob(RuntimeMoniker.Net60)]
+[MemoryDiagnoser]
+public class Utf8ArrayGetLengthBenchmark
+{
+    Utf8Array _value;
+
+    [Params("aα𩸽あbaα𩸽あbaα𩸽あbaα𩸽あbaα𩸽あb")]
+    public string? Value { get; set; }
+
+    [GlobalSetup]
+    public void Setup() => _value = new(Value!);
+
+    [Benchmark]
+    public int GetLength_Table() => _value.GetLength();
+
+    [Benchmark]
+    public int GetLength_Long()
+    {
+        const ulong Mask = 0x8080808080808080;
+
+        var count = 0;
+        nuint i = 0;
+        var length = _value.ByteCount - 8;
+
+        while ((int)i <= length)
+        {
+            var value = Unsafe.As<byte, ulong>(ref Unsafe.AddByteOffset(ref _value.DangerousGetReference(), i));
+            var x = ((value >> 6) | (~value >> 7)) & (Mask >> 7);
+            count += System.Numerics.BitOperations.PopCount(x);
+            i += 8;
+        }
+
+        while ((int)i < _value.ByteCount)
+        {
+            var value = Unsafe.AddByteOffset(ref _value.DangerousGetReference(), i);
+
+            if ((value & 0xC0) != 0x80)
+            {
+                count++;
+            }
+
+            i++;
+        }
+
+        return count;
+    }
+}

--- a/Source/Utf8Utility.Benchmarks/Utf8ArrayGetLengthBenchmark.cs
+++ b/Source/Utf8Utility.Benchmarks/Utf8ArrayGetLengthBenchmark.cs
@@ -11,11 +11,14 @@ public class Utf8ArrayGetLengthBenchmark
 {
     Utf8Array _value;
 
-    [Params("aα𩸽あbaα𩸽あbaα𩸽あbaα𩸽あbaα𩸽あb")]
+    [Params("abcd", "あいうえお", "あaαβaあααいうazzαああαabc")]
     public string? Value { get; set; }
 
+    [Params(1, 32, 1000)]
+    public int Count { get; set; }
+
     [GlobalSetup]
-    public void Setup() => _value = new(Value!);
+    public void Setup() => _value = new(string.Concat(Enumerable.Repeat(Value, Count)));
 
     [Benchmark]
     public int GetLength_Loop()

--- a/Source/Utf8Utility.Benchmarks/Utf8ArrayGetLengthBenchmark.cs
+++ b/Source/Utf8Utility.Benchmarks/Utf8ArrayGetLengthBenchmark.cs
@@ -1,8 +1,6 @@
-﻿using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Jobs;
-using Utf8Utility.Benchmarks.Helpers;
 
 namespace Utf8Utility.Benchmarks;
 
@@ -17,6 +15,27 @@ public class Utf8ArrayGetLengthBenchmark
 
     [GlobalSetup]
     public void Setup() => _value = new(Value!);
+
+    [Benchmark]
+    public int GetLength_Loop()
+    {
+        var count = 0;
+        nuint i = 0;
+
+        while ((int)i < _value.ByteCount)
+        {
+            var value = Unsafe.AddByteOffset(ref _value.DangerousGetReference(), i);
+
+            if ((value & 0xC0) != 0x80)
+            {
+                count++;
+            }
+
+            i++;
+        }
+
+        return count;
+    }
 
     [Benchmark]
     public int GetLength_Table() => _value.GetLength();

--- a/Source/Utf8Utility.Benchmarks/Utf8ArrayGetLengthBenchmark.cs
+++ b/Source/Utf8Utility.Benchmarks/Utf8ArrayGetLengthBenchmark.cs
@@ -12,7 +12,7 @@ public class Utf8ArrayGetLengthBenchmark
     [Params("abcd", "あいうえお", "あaαβaあααいうazzαああαabc")]
     public string? Value { get; set; }
 
-    [Params(1, 32, 1000)]
+    [Params(1, 1000)]
     public int Count { get; set; }
 
     [GlobalSetup]

--- a/Source/Utf8Utility.Benchmarks/Utf8ArrayGetLengthBenchmark.cs
+++ b/Source/Utf8Utility.Benchmarks/Utf8ArrayGetLengthBenchmark.cs
@@ -4,7 +4,7 @@ using BenchmarkDotNet.Attributes;
 
 namespace Utf8Utility.Benchmarks;
 
-[Config(typeof(BenchmarkConfig)]
+[Config(typeof(BenchmarkConfig))]
 public class Utf8ArrayGetLengthBenchmark
 {
     Utf8Array _value;

--- a/Source/Utf8Utility/Utf8Array.cs
+++ b/Source/Utf8Utility/Utf8Array.cs
@@ -263,92 +263,15 @@ public readonly partial struct Utf8Array : IEquatable<Utf8Array>,
             count += BitOperations.PopCount(x);
             index += sizeof(ulong);
         }
-
-        //while ((int)index < ByteCount)
-        //{
-        //    var value = Unsafe.AddByteOffset(ref _value.DangerousGetReference(), index);
-
-        //    if ((value & 0xC0) != 0x80)
-        //    {
-        //        count++;
-        //    }
-
-        //    index++;
-        //}
-
-        if ((int)index < ByteCount - Vector<int>.Count)
-        {
-            ref var start = ref Unsafe.AddByteOffset(ref _value.DangerousGetReference(), index);
-
-            for (var i = 0; i < Vector<int>.Count; i++)
-            {
-                var value = Unsafe.AddByteOffset(ref start, (nint)(uint)i);
-
-                if ((value & 0xC0) != 0x80)
-                {
-                    count++;
-                }
-            }
-
-            index += (uint)Vector<int>.Count;
-        }
+#endif
 
         while ((int)index < ByteCount)
         {
-            var value = Unsafe.AddByteOffset(ref _value.DangerousGetReference(), index);
-
-            if ((value & 0xC0) != 0x80)
-            {
-                count++;
-            }
-
-            index++;
-        }
-#else
-        while ((int)index < _value.Length)
-        {
-            ref var valueStart = ref DangerousGetReference();
-
-            // 最適化の関係でrefローカル変数にしてはいけない。
 #if NET6_0_OR_GREATER
-            var value = Unsafe.AddByteOffset(ref valueStart, index);
+            var value = Unsafe.AddByteOffset(ref _value.DangerousGetReference(), (nint)index);
 #else
-            var value = Unsafe.AddByteOffset(ref valueStart, (nint)index);
+            var value = Unsafe.AddByteOffset(ref _value.DangerousGetReference(), (nint)index);
 #endif
-            index += (uint)UnicodeUtility.GetUtf8SequenceLength(value);
-            count++;
-        }
-#endif
-
-        return count;
-    }
-
-#if NET6_0_OR_GREATER
-    public int GetLength2()
-    {
-        var count = 0;
-        nuint index = 0;
-
-        var x = ByteCount / Vector<int>.Count;
-
-        for (; (int)index < x; index += (uint)Vector<int>.Count)
-        {
-            ref var start = ref Unsafe.AddByteOffset(ref _value.DangerousGetReference(), (nint)(uint)index);
-
-            for (var i = 0; i < Vector<int>.Count; i++)
-            {
-                var value = Unsafe.AddByteOffset(ref start, (nint)(uint)i);
-
-                if ((value & 0xC0) != 0x80)
-                {
-                    count++;
-                }
-            }
-        }
-
-        while ((int)index < ByteCount)
-        {
-            var value = Unsafe.AddByteOffset(ref _value.DangerousGetReference(), index);
 
             if ((value & 0xC0) != 0x80)
             {
@@ -360,7 +283,6 @@ public readonly partial struct Utf8Array : IEquatable<Utf8Array>,
 
         return count;
     }
-#endif
 
 #if NET6_0_OR_GREATER
     /// <summary>

--- a/Source/Utf8Utility/Utf8Array.cs
+++ b/Source/Utf8Utility/Utf8Array.cs
@@ -272,7 +272,7 @@ public readonly partial struct Utf8Array : IEquatable<Utf8Array>,
         {
             // 最適化の関係でrefローカル変数にしてはいけない。
 #if NET6_0_OR_GREATER
-            var value = Unsafe.AddByteOffset(ref _value.DangerousGetReference(), (nint)index);
+            var value = Unsafe.AddByteOffset(ref _value.DangerousGetReference(), index);
 #else
             var value = Unsafe.AddByteOffset(ref _value.DangerousGetReference(), (nint)index);
 #endif

--- a/Source/Utf8Utility/Utf8Array.cs
+++ b/Source/Utf8Utility/Utf8Array.cs
@@ -1,9 +1,7 @@
 ﻿using System.Diagnostics.CodeAnalysis;
-using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Text;
 using Microsoft.Toolkit.HighPerformance;
-using Microsoft.Toolkit.HighPerformance.Helpers;
 using Utf8Utility.Text;
 #if NET6_0_OR_GREATER
 using System.Buffers;
@@ -271,96 +269,6 @@ public readonly partial struct Utf8Array : IEquatable<Utf8Array>,
     }
 
 #if NET6_0_OR_GREATER
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public int GetLength_Long2()
-    {
-        const ulong Mask = 0x8080808080808080;
-
-        var count = 0;
-        nuint i = 0;
-        var length = ByteCount - (8 * 4);
-
-        while ((int)i <= length)
-        {
-            ref var value = ref Unsafe.As<byte, ulong>(ref Unsafe.AddByteOffset(ref _value.DangerousGetReference(), i));
-            var value0 = value;
-            var value1 = Unsafe.Add(ref value, 1);
-            var value2 = Unsafe.Add(ref value, 2);
-            var value3 = Unsafe.Add(ref value, 3);
-
-            count += System.Numerics.BitOperations.PopCount(((value0 >> 6) | (~value0 >> 7)) & (Mask >> 7));
-            count += System.Numerics.BitOperations.PopCount(((value1 >> 6) | (~value1 >> 7)) & (Mask >> 7));
-            count += System.Numerics.BitOperations.PopCount(((value2 >> 6) | (~value2 >> 7)) & (Mask >> 7));
-            count += System.Numerics.BitOperations.PopCount(((value3 >> 6) | (~value3 >> 7)) & (Mask >> 7));
-            i += 8 * 4;
-        }
-
-        length = ByteCount - 8;
-
-        while ((int)i <= length)
-        {
-            var value = Unsafe.As<byte, ulong>(ref Unsafe.AddByteOffset(ref _value.DangerousGetReference(), i));
-            var x = ((value >> 6) | (~value >> 7)) & (Mask >> 7);
-            count += System.Numerics.BitOperations.PopCount(x);
-            i += 8;
-        }
-
-        while ((int)i < ByteCount)
-        {
-            var value = Unsafe.AddByteOffset(ref _value.DangerousGetReference(), i);
-
-            if ((value & 0xC0) != 0x80)
-            {
-                count++;
-            }
-
-            i++;
-        }
-
-        return count;
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public unsafe int GetLength_Parallel()
-    {
-        var count = 0;
-        var length = ByteCount / 8;
-
-        var array = Unsafe.As<ulong[]>(_value);
-        ParallelHelper.ForEach<ulong, Calc>(new Memory<ulong>(array, 0, length), new Calc(&count));
-
-        nuint i = (uint)length * 8;
-
-        while ((int)i < ByteCount)
-        {
-            var value = Unsafe.AddByteOffset(ref _value.DangerousGetReference(), i);
-
-            if ((value & 0xC0) != 0x80)
-            {
-                count++;
-            }
-
-            i++;
-        }
-
-        return count;
-    }
-
-    readonly unsafe struct Calc : IInAction<ulong>
-    {
-        readonly int* _ptr;
-
-        public Calc(int* ptr) => _ptr = ptr;
-
-        public void Invoke(in ulong item)
-        {
-            const ulong Mask = 0x8080808080808080;
-
-            var x = ((item >> 6) | (~item >> 7)) & (Mask >> 7);
-            Interlocked.Add(ref Unsafe.AsRef<int>(_ptr), BitOperations.PopCount(x));
-        }
-    }
-
     /// <summary>
     /// UTF-8配列が空または空白かどうかを判定します。
     /// </summary>

--- a/Tests/Utf8Utility.Tests/Utf8ArrayGetLengthTest.cs
+++ b/Tests/Utf8Utility.Tests/Utf8ArrayGetLengthTest.cs
@@ -1,4 +1,5 @@
 ﻿using System.Globalization;
+using System.Text;
 using FluentAssertions;
 using Xunit;
 
@@ -23,6 +24,24 @@ public sealed class Utf8ArrayGetLengthTest
     {
         var array = new Utf8Array(value);
         var info = new StringInfo(value);
+        array.GetLength().Should().Be(info.LengthInTextElements);
+    }
+
+    [Fact]
+    public void LongTest()
+    {
+        const int Count = 32;
+        var builder = new StringBuilder();
+
+        for (var i = 0; i < Count; i++)
+        {
+            builder.Append("aαあ𩸽");
+        }
+
+        var value = builder.ToString();
+        var array = new Utf8Array(value);
+        var info = new StringInfo(value);
+
         array.GetLength().Should().Be(info.LengthInTextElements);
     }
 }


### PR DESCRIPTION
``` ini

BenchmarkDotNet=v0.13.1, OS=Windows 10.0.19043.1288 (21H1/May2021Update)
AMD Ryzen 7 5800U with Radeon Graphics, 1 CPU, 16 logical and 8 physical cores
.NET SDK=6.0.100-rc.2.21505.57
  [Host]             : .NET 6.0.0 (6.0.21.48005), X64 RyuJIT
  DisableHWIntrinsic : .NET 6.0.0 (6.0.21.48005), X64 RyuJIT
  Runtime=.NET 6.0   : .NET 6.0.0 (6.0.21.48005), X64 RyuJIT

Runtime=.NET 6.0  

```
|          Method |                Job |        EnvironmentVariables |                Value | Count |          Mean |      Error |     StdDev | Ratio | RatioSD | Allocated |
|---------------- |------------------- |---------------------------- |--------------------- |------ |--------------:|-----------:|-----------:|------:|--------:|----------:|
|  **GetLength_Loop** | **DisableHWIntrinsic** | **COMPlus_EnableHWIntrinsic=0** |                 **abcd** |     **1** |      **1.740 ns** |  **0.0107 ns** |  **0.0094 ns** |  **0.74** |    **0.00** |         **-** |
| GetLength_Table | DisableHWIntrinsic | COMPlus_EnableHWIntrinsic=0 |                 abcd |     1 |      2.420 ns |  0.0109 ns |  0.0102 ns |  1.03 |    0.00 |         - |
|  GetLength_Long | DisableHWIntrinsic | COMPlus_EnableHWIntrinsic=0 |                 abcd |     1 |      2.339 ns |  0.0075 ns |  0.0070 ns |  1.00 |    0.00 |         - |
|                 |                    |                             |                      |       |               |            |            |       |         |           |
|  GetLength_Loop |   Runtime=.NET 6.0 |                       Empty |                 abcd |     1 |      1.728 ns |  0.0084 ns |  0.0070 ns |  0.89 |    0.00 |         - |
| GetLength_Table |   Runtime=.NET 6.0 |                       Empty |                 abcd |     1 |      2.421 ns |  0.0082 ns |  0.0077 ns |  1.24 |    0.01 |         - |
|  GetLength_Long |   Runtime=.NET 6.0 |                       Empty |                 abcd |     1 |      1.947 ns |  0.0079 ns |  0.0074 ns |  1.00 |    0.00 |         - |
|                 |                    |                             |                      |       |               |            |            |       |         |           |
|  **GetLength_Loop** | **DisableHWIntrinsic** | **COMPlus_EnableHWIntrinsic=0** |                 **abcd** |  **1000** |  **1,840.116 ns** |  **4.2662 ns** |  **3.9906 ns** |  **1.98** |    **0.01** |         **-** |
| GetLength_Table | DisableHWIntrinsic | COMPlus_EnableHWIntrinsic=0 |                 abcd |  1000 |  8,133.821 ns |  5.4448 ns |  5.0930 ns |  8.77 |    0.03 |         - |
|  GetLength_Long | DisableHWIntrinsic | COMPlus_EnableHWIntrinsic=0 |                 abcd |  1000 |    927.885 ns |  3.3249 ns |  3.1101 ns |  1.00 |    0.00 |         - |
|                 |                    |                             |                      |       |               |            |            |       |         |           |
|  GetLength_Loop |   Runtime=.NET 6.0 |                       Empty |                 abcd |  1000 |  1,839.473 ns |  3.1285 ns |  2.9264 ns |  5.26 |    0.01 |         - |
| GetLength_Table |   Runtime=.NET 6.0 |                       Empty |                 abcd |  1000 |  8,125.733 ns |  0.7248 ns |  0.6426 ns | 23.24 |    0.05 |         - |
|  GetLength_Long |   Runtime=.NET 6.0 |                       Empty |                 abcd |  1000 |    349.620 ns |  0.7187 ns |  0.6723 ns |  1.00 |    0.00 |         - |
|                 |                    |                             |                      |       |               |            |            |       |         |           |
|  **GetLength_Loop** | **DisableHWIntrinsic** | **COMPlus_EnableHWIntrinsic=0** | **あaαβaあααいうazzαああαabc** |     **1** |     **17.192 ns** |  **0.0455 ns** |  **0.0380 ns** |  **1.55** |    **0.00** |         **-** |
| GetLength_Table | DisableHWIntrinsic | COMPlus_EnableHWIntrinsic=0 | あaαβaあααいうazzαああαabc |     1 |     37.564 ns |  0.0516 ns |  0.0457 ns |  3.39 |    0.01 |         - |
|  GetLength_Long | DisableHWIntrinsic | COMPlus_EnableHWIntrinsic=0 | あaαβaあααいうazzαああαabc |     1 |     11.068 ns |  0.0216 ns |  0.0202 ns |  1.00 |    0.00 |         - |
|                 |                    |                             |                      |       |               |            |            |       |         |           |
|  GetLength_Loop |   Runtime=.NET 6.0 |                       Empty | あaαβaあααいうazzαああαabc |     1 |     21.603 ns |  0.0518 ns |  0.0485 ns |  3.70 |    0.01 |         - |
| GetLength_Table |   Runtime=.NET 6.0 |                       Empty | あaαβaあααいうazzαああαabc |     1 |     37.590 ns |  0.0282 ns |  0.0250 ns |  6.45 |    0.02 |         - |
|  GetLength_Long |   Runtime=.NET 6.0 |                       Empty | あaαβaあααいうazzαああαabc |     1 |      5.831 ns |  0.0192 ns |  0.0161 ns |  1.00 |    0.00 |         - |
|                 |                    |                             |                      |       |               |            |            |       |         |           |
|  **GetLength_Loop** | **DisableHWIntrinsic** | **COMPlus_EnableHWIntrinsic=0** | **あaαβaあααいうazzαああαabc** |  **1000** | **21,654.369 ns** | **25.0355 ns** | **22.1933 ns** |  **2.46** |    **0.00** |         **-** |
| GetLength_Table | DisableHWIntrinsic | COMPlus_EnableHWIntrinsic=0 | あaαβaあααいうazzαああαabc |  1000 | 40,656.742 ns | 36.2314 ns | 33.8909 ns |  4.62 |    0.01 |         - |
|  GetLength_Long | DisableHWIntrinsic | COMPlus_EnableHWIntrinsic=0 | あaαβaあααいうazzαああαabc |  1000 |  8,810.101 ns | 17.0358 ns | 15.1018 ns |  1.00 |    0.00 |         - |
|                 |                    |                             |                      |       |               |            |            |       |         |           |
|  GetLength_Loop |   Runtime=.NET 6.0 |                       Empty | あaαβaあααいうazzαああαabc |  1000 | 17,517.835 ns | 33.8446 ns | 31.6583 ns |  5.32 |    0.01 |         - |
| GetLength_Table |   Runtime=.NET 6.0 |                       Empty | あaαβaあααいうazzαああαabc |  1000 | 40,637.298 ns | 31.3999 ns | 29.3715 ns | 12.34 |    0.02 |         - |
|  GetLength_Long |   Runtime=.NET 6.0 |                       Empty | あaαβaあααいうazzαああαabc |  1000 |  3,292.158 ns |  5.3376 ns |  4.9928 ns |  1.00 |    0.00 |         - |
|                 |                    |                             |                      |       |               |            |            |       |         |           |
|  **GetLength_Loop** | **DisableHWIntrinsic** | **COMPlus_EnableHWIntrinsic=0** |                **あいうえお** |     **1** |      **8.916 ns** |  **0.0124 ns** |  **0.0110 ns** |  **1.74** |    **0.00** |         **-** |
| GetLength_Table | DisableHWIntrinsic | COMPlus_EnableHWIntrinsic=0 |                あいうえお |     1 |      2.867 ns |  0.0203 ns |  0.0180 ns |  0.56 |    0.00 |         - |
|  GetLength_Long | DisableHWIntrinsic | COMPlus_EnableHWIntrinsic=0 |                あいうえお |     1 |      5.129 ns |  0.0141 ns |  0.0132 ns |  1.00 |    0.00 |         - |
|                 |                    |                             |                      |       |               |            |            |       |         |           |
|  GetLength_Loop |   Runtime=.NET 6.0 |                       Empty |                あいうえお |     1 |      8.919 ns |  0.0115 ns |  0.0108 ns |  2.32 |    0.01 |         - |
| GetLength_Table |   Runtime=.NET 6.0 |                       Empty |                あいうえお |     1 |      2.856 ns |  0.0155 ns |  0.0137 ns |  0.74 |    0.00 |         - |
|  GetLength_Long |   Runtime=.NET 6.0 |                       Empty |                あいうえお |     1 |      3.841 ns |  0.0118 ns |  0.0111 ns |  1.00 |    0.00 |         - |
|                 |                    |                             |                      |       |               |            |            |       |         |           |
|  **GetLength_Loop** | **DisableHWIntrinsic** | **COMPlus_EnableHWIntrinsic=0** |                **あいうえお** |  **1000** |  **9,213.676 ns** | **17.3948 ns** | **16.2711 ns** |  **2.37** |    **0.00** |         **-** |
| GetLength_Table | DisableHWIntrinsic | COMPlus_EnableHWIntrinsic=0 |                あいうえお |  1000 | 10,155.889 ns |  1.4181 ns |  1.2571 ns |  2.61 |    0.00 |         - |
|  GetLength_Long | DisableHWIntrinsic | COMPlus_EnableHWIntrinsic=0 |                あいうえお |  1000 |  3,890.028 ns |  4.0534 ns |  3.7915 ns |  1.00 |    0.00 |         - |
|                 |                    |                             |                      |       |               |            |            |       |         |           |
|  GetLength_Loop |   Runtime=.NET 6.0 |                       Empty |                あいうえお |  1000 |  6,920.692 ns |  9.5854 ns |  8.9662 ns |  5.34 |    0.01 |         - |
| GetLength_Table |   Runtime=.NET 6.0 |                       Empty |                あいうえお |  1000 | 10,163.939 ns |  8.1335 ns |  7.6081 ns |  7.84 |    0.02 |         - |
|  GetLength_Long |   Runtime=.NET 6.0 |                       Empty |                あいうえお |  1000 |  1,296.935 ns |  2.9480 ns |  2.7575 ns |  1.00 |    0.00 |         - |