### PR TITLE
UTF-8文字数取得処理を最適化

### DIFF
--- a/Source/Utf8Utility.Benchmarks/Utf8GetLengthBenchmark.cs
+++ b/Source/Utf8Utility.Benchmarks/Utf8GetLengthBenchmark.cs
@@ -402,7 +402,7 @@ public class Utf8GetLengthBenchmark
         return count;
     }
 
-    [Benchmark()]
+    [Benchmark]
     public int GetLength_Avx2_4()
     {
         var count = 0;
@@ -412,22 +412,22 @@ public class Utf8GetLengthBenchmark
 
         if (_value.Length >= Vector256<byte>.Count)
         {
-            ref var e = ref Unsafe.AddByteOffset(ref start, (nint)(uint)_value.Length);
             end = ref Unsafe.SubtractByteOffset(ref end, Vector256<byte>.Count);
+
+            nuint i = 0;
+            var length32 = (nuint)(_value.Length & -Vector256<byte>.Count);
 
             do
             {
                 var sum = Vector256<byte>.Zero;
-                var end2 = Math.Min(255 * 32, Unsafe.ByteOffset(ref start, ref e) / 32 * 32);
-                var i = 0;
+                var limit = Math.Min((nuint)(255 * Vector256<byte>.Count), length32 - i);
+                nuint j = 0;
 
-                do
+                for (; j < limit; j += (nuint)Vector256<byte>.Count)
                 {
-                    var s = Vector256.LoadUnsafe(ref start, (nuint)i);
-                    sum = Avx2.Subtract(sum, Avx2.CompareGreaterThan(s.AsSByte(), Vector256.Create<sbyte>(-0x41)).AsByte());
-                    i += 32;
+                    var vector = Vector256.LoadUnsafe(ref start, j);
+                    sum = Avx2.Subtract(sum, Avx2.CompareGreaterThan(vector.AsSByte(), Vector256.Create<sbyte>(-0x41)).AsByte());
                 }
-                while (i < end2);
 
                 var sumHigh = Avx2.UnpackHigh(sum, Vector256<byte>.Zero);
                 var sumLow = Avx2.UnpackLow(sum, Vector256<byte>.Zero);
@@ -443,12 +443,91 @@ public class Utf8GetLengthBenchmark
                 count += (int)((temp >> 32) & 0xffff);
                 count += (int)((temp >> 48) & 0xffff);
 
-                start = ref Unsafe.AddByteOffset(ref start, (nint)(uint)i);
+                i += j;
+                start = ref Unsafe.AddByteOffset(ref start, j);
             }
             while (!Unsafe.IsAddressGreaterThan(ref start, ref end));
 
 
             end = ref Unsafe.AddByteOffset(ref end, Vector256<byte>.Count);
+        }
+
+        if (Unsafe.ByteOffset(ref start, ref end) >= sizeof(ulong))
+        {
+            end = ref Unsafe.SubtractByteOffset(ref end, sizeof(ulong));
+
+            do
+            {
+                var number = Unsafe.ReadUnaligned<ulong>(ref start);
+
+                const ulong Mask = 0x8080808080808080 >> 7;
+                var x = ((number >> 6) | (~number >> 7)) & Mask;
+
+                count += BitOperations.PopCount(x);
+                start = ref Unsafe.AddByteOffset(ref start, sizeof(ulong));
+            }
+            while (!Unsafe.IsAddressGreaterThan(ref start, ref end));
+
+            end = ref Unsafe.AddByteOffset(ref end, sizeof(ulong));
+        }
+
+        while (Unsafe.IsAddressLessThan(ref start, ref end))
+        {
+            if ((start & 0xC0) != 0x80)
+            {
+                count++;
+            }
+
+            start = ref Unsafe.AddByteOffset(ref start, 1);
+        }
+
+        return count;
+    }
+
+    [Benchmark]
+    public int GetLength_Avx2_5()
+    {
+        var count = 0;
+
+        ref var start = ref MemoryMarshal.GetArrayDataReference(_value);
+        ref var end = ref Unsafe.AddByteOffset(ref start, (nint)(uint)_value.Length);
+
+        if (_value.Length >= Vector256<byte>.Count)
+        {
+            nuint i = 0;
+            var length32 = (nuint)(_value.Length & -Vector256<byte>.Count);
+
+            do
+            {
+                var sum = Vector256<byte>.Zero;
+                var limit = Math.Min((nuint)(255 * Vector256<byte>.Count), length32 - i);
+                nuint j = 0;
+
+                for (; j < limit; j += (nuint)Vector256<byte>.Count)
+                {
+                    var vector = Vector256.LoadUnsafe(ref start, j);
+                    sum = Avx2.Subtract(sum, Avx2.CompareGreaterThan(vector.AsSByte(), Vector256.Create<sbyte>(-0x41)).AsByte());
+                }
+
+                var sumHigh = Avx2.UnpackHigh(sum, Vector256<byte>.Zero);
+                var sumLow = Avx2.UnpackLow(sum, Vector256<byte>.Zero);
+                var sum16x16 = Avx2.Add(sumHigh.AsInt16(), sumLow.AsInt16());
+                var sum16x8 = Avx2.Add(sum16x16, Avx2.Permute2x128(sum16x16, sum16x16, 1));
+
+                const byte Control = (0 << 6) | (0 << 4) | (2 << 2) | 3;
+                var sum16x4 = Avx2.Add(sum16x8, Avx2.Shuffle(sum16x8.AsInt32(), Control).AsInt16());
+
+                var temp = sum16x4.AsInt64().GetElement(0);
+                count += (int)((temp >> 0) & 0xffff);
+                count += (int)((temp >> 16) & 0xffff);
+                count += (int)((temp >> 32) & 0xffff);
+                count += (int)((temp >> 48) & 0xffff);
+
+                i += j;
+            }
+            while (i < length32);
+
+            start = ref Unsafe.AddByteOffset(ref start, i);
         }
 
         if (Unsafe.ByteOffset(ref start, ref end) >= sizeof(ulong))

--- a/Source/Utf8Utility.Benchmarks/Utf8GetLengthBenchmark.cs
+++ b/Source/Utf8Utility.Benchmarks/Utf8GetLengthBenchmark.cs
@@ -17,7 +17,7 @@ public class Utf8GetLengthBenchmark
     [Params("a")]
     public string? Value { get; set; }
 
-    [Params(10, 63, 64, 95, 96, 1000, 10000)]
+    [Params(/*10, 63, 64, 95, 96,*/ 10000)]
     public int Count { get; set; }
 
     [GlobalSetup]
@@ -33,7 +33,7 @@ public class Utf8GetLengthBenchmark
         _value = Encoding.UTF8.GetBytes(builder.ToString());
     }
 
-    [Benchmark]
+    //[Benchmark]
     public int GetLength_Table()
     {
         var count = 0;
@@ -52,7 +52,7 @@ public class Utf8GetLengthBenchmark
         return count;
     }
 
-    [Benchmark]
+    //[Benchmark]
     public int GetLength_Byte()
     {
         var count = 0;
@@ -73,7 +73,7 @@ public class Utf8GetLengthBenchmark
         return count;
     }
 
-    [Benchmark]
+    //[Benchmark]
     public int GetLength_PopCount()
     {
         var count = 0;
@@ -112,7 +112,7 @@ public class Utf8GetLengthBenchmark
         return count;
     }
 
-    [Benchmark]
+    //[Benchmark]
     public int GetLength_PopCount_SoftwareFallback()
     {
         var count = 0;
@@ -176,7 +176,7 @@ public class Utf8GetLengthBenchmark
             do
             {
                 var sum = Vector256<byte>.Zero;
-                ref var end2 = ref Unsafe.AddByteOffset(ref start, Math.Min(255 * 32, Unsafe.ByteOffset(ref start, ref end)));
+                ref var end2 = ref Unsafe.AddByteOffset(ref start, (nint)(uint)Math.Min(255 * 32, Unsafe.ByteOffset(ref start, ref end)));
 
                 do
                 {
@@ -202,6 +202,170 @@ public class Utf8GetLengthBenchmark
             }
             while (!Unsafe.IsAddressGreaterThan(ref start, ref end));
 
+            end = ref Unsafe.AddByteOffset(ref end, Vector256<byte>.Count);
+        }
+
+        if (Unsafe.ByteOffset(ref start, ref end) >= sizeof(ulong))
+        {
+            end = ref Unsafe.SubtractByteOffset(ref end, sizeof(ulong));
+
+            do
+            {
+                var number = Unsafe.ReadUnaligned<ulong>(ref start);
+
+                const ulong Mask = 0x8080808080808080 >> 7;
+                var x = ((number >> 6) | (~number >> 7)) & Mask;
+
+                count += BitOperations.PopCount(x);
+                start = ref Unsafe.AddByteOffset(ref start, sizeof(ulong));
+            }
+            while (!Unsafe.IsAddressGreaterThan(ref start, ref end));
+
+            end = ref Unsafe.AddByteOffset(ref end, sizeof(ulong));
+        }
+
+        while (Unsafe.IsAddressLessThan(ref start, ref end))
+        {
+            if ((start & 0xC0) != 0x80)
+            {
+                count++;
+            }
+
+            start = ref Unsafe.AddByteOffset(ref start, 1);
+        }
+
+        return count;
+    }
+
+    [Benchmark]
+    public int GetLength_Avx2_2()
+    {
+        var count = 0;
+
+        ref var start = ref MemoryMarshal.GetArrayDataReference(_value);
+        ref var end = ref Unsafe.AddByteOffset(ref start, (nint)(uint)_value.Length);
+
+        if (_value.Length >= Vector256<byte>.Count)
+        {
+            end = ref Unsafe.SubtractByteOffset(ref end, Vector256<byte>.Count);
+            var i = 0;
+
+            do
+            {
+                var sum = Vector256<byte>.Zero;
+                //ref var end2 = ref Unsafe.AddByteOffset(ref start, Math.Min(255 * 32, Unsafe.ByteOffset(ref start, ref end)));
+                var limit = Math.Min(255 * 32, _value.Length / 32 * 32 - i);
+                var j = 0;
+
+                for (; j < limit; j += 32)
+                {
+                    var s = Vector256.LoadUnsafe(ref start, (nuint)(j));
+                    sum = Avx2.Subtract(sum, Avx2.CompareGreaterThan(s.AsSByte(), Vector256.Create<sbyte>(-0x41)).AsByte());
+
+                }
+
+                var sumHigh = Avx2.UnpackHigh(sum, Vector256<byte>.Zero);
+                var sumLow = Avx2.UnpackLow(sum, Vector256<byte>.Zero);
+                var sum16x16 = Avx2.Add(sumHigh.AsInt16(), sumLow.AsInt16());
+                var sum16x8 = Avx2.Add(sum16x16, Avx2.Permute2x128(sum16x16, sum16x16, 1));
+
+                const byte Control = (0 << 6) | (0 << 4) | (2 << 2) | 3;
+                var sum16x4 = Avx2.Add(sum16x8, Avx2.Shuffle(sum16x8.AsInt32(), Control).AsInt16());
+
+                var temp = sum16x4.AsInt64().GetElement(0);
+                count += (int)((temp >> 0) & 0xffff);
+                count += (int)((temp >> 16) & 0xffff);
+                count += (int)((temp >> 32) & 0xffff);
+                count += (int)((temp >> 48) & 0xffff);
+
+                i += j;
+                start = ref Unsafe.AddByteOffset(ref start, (nint)(uint)j);
+            }
+            while (!Unsafe.IsAddressGreaterThan(ref start, ref end));
+
+
+            end = ref Unsafe.AddByteOffset(ref end, Vector256<byte>.Count);
+        }
+
+        if (Unsafe.ByteOffset(ref start, ref end) >= sizeof(ulong))
+        {
+            end = ref Unsafe.SubtractByteOffset(ref end, sizeof(ulong));
+
+            do
+            {
+                var number = Unsafe.ReadUnaligned<ulong>(ref start);
+
+                const ulong Mask = 0x8080808080808080 >> 7;
+                var x = ((number >> 6) | (~number >> 7)) & Mask;
+
+                count += BitOperations.PopCount(x);
+                start = ref Unsafe.AddByteOffset(ref start, sizeof(ulong));
+            }
+            while (!Unsafe.IsAddressGreaterThan(ref start, ref end));
+
+            end = ref Unsafe.AddByteOffset(ref end, sizeof(ulong));
+        }
+
+        while (Unsafe.IsAddressLessThan(ref start, ref end))
+        {
+            if ((start & 0xC0) != 0x80)
+            {
+                count++;
+            }
+
+            start = ref Unsafe.AddByteOffset(ref start, 1);
+        }
+
+        return count;
+    }
+
+    [Benchmark]
+    public int GetLength_Avx2_3()
+    {
+        var count = 0;
+
+        ref var start = ref MemoryMarshal.GetArrayDataReference(_value);
+        ref var end = ref Unsafe.AddByteOffset(ref start, (nint)(uint)_value.Length);
+
+        if (_value.Length >= Vector256<byte>.Count)
+        {
+            end = ref Unsafe.SubtractByteOffset(ref end, Vector256<byte>.Count);
+            var i = 0;
+            var l = _value.Length / 32 * 32;
+
+            for (; i < l;)
+            {
+                var sum = Vector256<byte>.Zero;
+                //ref var end2 = ref Unsafe.AddByteOffset(ref start, Math.Min(255 * 32, Unsafe.ByteOffset(ref start, ref end)));
+                var limit = Math.Min(255 * 32, l - i);
+                var j = 0;
+
+                for (; j < limit; j += 32)
+                {
+                    var s = Vector256.LoadUnsafe(ref start, (nuint)(i + j));
+                    sum = Avx2.Subtract(sum, Avx2.CompareGreaterThan(s.AsSByte(), Vector256.Create<sbyte>(-0x41)).AsByte());
+
+                }
+
+                var sumHigh = Avx2.UnpackHigh(sum, Vector256<byte>.Zero);
+                var sumLow = Avx2.UnpackLow(sum, Vector256<byte>.Zero);
+                var sum16x16 = Avx2.Add(sumHigh.AsInt16(), sumLow.AsInt16());
+                var sum16x8 = Avx2.Add(sum16x16, Avx2.Permute2x128(sum16x16, sum16x16, 1));
+
+                const byte Control = (0 << 6) | (0 << 4) | (2 << 2) | 3;
+                var sum16x4 = Avx2.Add(sum16x8, Avx2.Shuffle(sum16x8.AsInt32(), Control).AsInt16());
+
+                var temp = sum16x4.AsInt64().GetElement(0);
+                count += (int)((temp >> 0) & 0xffff);
+                count += (int)((temp >> 16) & 0xffff);
+                count += (int)((temp >> 32) & 0xffff);
+                count += (int)((temp >> 48) & 0xffff);
+
+                i += j;
+
+            }
+
+            start = ref Unsafe.AddByteOffset(ref start, (nint)(uint)i);
             end = ref Unsafe.AddByteOffset(ref end, Vector256<byte>.Count);
         }
 

--- a/Source/Utf8Utility.Benchmarks/Utf8GetLengthBenchmark.cs
+++ b/Source/Utf8Utility.Benchmarks/Utf8GetLengthBenchmark.cs
@@ -184,7 +184,7 @@ public class Utf8GetLengthBenchmark
                     sum = Avx2.Subtract(sum, Avx2.CompareGreaterThan(s.AsSByte(), Vector256.Create<sbyte>(-0x41)).AsByte());
                     start = ref Unsafe.AddByteOffset(ref start, Vector256<byte>.Count);
                 }
-                while (!Unsafe.IsAddressGreaterThan(ref start, ref end2));
+                while (Unsafe.IsAddressLessThan(ref start, ref end2));
 
                 var sumHigh = Avx2.UnpackHigh(sum, Vector256<byte>.Zero);
                 var sumLow = Avx2.UnpackLow(sum, Vector256<byte>.Zero);

--- a/Source/Utf8Utility.Benchmarks/Utf8GetLengthBenchmark.cs
+++ b/Source/Utf8Utility.Benchmarks/Utf8GetLengthBenchmark.cs
@@ -256,11 +256,13 @@ public class Utf8GetLengthBenchmark
                 var limit = Math.Min((nuint)(255 * Vector256<byte>.Count), length32 - i);
                 nuint j = 0;
 
-                for (; j < limit; j += (nuint)Vector256<byte>.Count)
+                do
                 {
                     var vector = Vector256.LoadUnsafe(ref start, j);
                     sum = Avx2.Subtract(sum, Avx2.CompareGreaterThan(vector.AsSByte(), Vector256.Create<sbyte>(-0x41)).AsByte());
+                    j += (nuint)Vector256<byte>.Count;
                 }
+                while (j < limit);
 
                 var sumHigh = Avx2.UnpackHigh(sum, Vector256<byte>.Zero);
                 var sumLow = Avx2.UnpackLow(sum, Vector256<byte>.Zero);

--- a/Source/Utf8Utility.Benchmarks/Utf8GetLengthBenchmark.cs
+++ b/Source/Utf8Utility.Benchmarks/Utf8GetLengthBenchmark.cs
@@ -131,10 +131,10 @@ public class Utf8GetLengthBenchmark
                 const ulong Mask = 0x8080808080808080 >> 7;
                 var x = ((number >> 6) | (~number >> 7)) & Mask;
 
-                const ulong C1 = 0x_55555555_55555555ul;
-                const ulong C2 = 0x_33333333_33333333ul;
-                const ulong C3 = 0x_0F0F0F0F_0F0F0F0Ful;
-                const ulong C4 = 0x_01010101_01010101ul;
+                const ulong C1 = 0x_55555555_55555555;
+                const ulong C2 = 0x_33333333_33333333;
+                const ulong C3 = 0x_0F0F0F0F_0F0F0F0F;
+                const ulong C4 = 0x_01010101_01010101;
 
                 x -= (x >> 1) & C1;
                 x = (x & C2) + ((x >> 2) & C2);

--- a/Source/Utf8Utility.Benchmarks/Utf8GetLengthBenchmark.cs
+++ b/Source/Utf8Utility.Benchmarks/Utf8GetLengthBenchmark.cs
@@ -33,7 +33,7 @@ public class Utf8GetLengthBenchmark
         _value = Encoding.UTF8.GetBytes(builder.ToString());
     }
 
-   // [Benchmark]
+    [Benchmark]
     public int GetLength_Table()
     {
         var count = 0;
@@ -52,7 +52,7 @@ public class Utf8GetLengthBenchmark
         return count;
     }
 
-   // [Benchmark]
+    [Benchmark]
     public int GetLength_Byte()
     {
         var count = 0;
@@ -73,7 +73,7 @@ public class Utf8GetLengthBenchmark
         return count;
     }
 
-    //[Benchmark]
+    [Benchmark]
     public int GetLength_PopCount()
     {
         var count = 0;
@@ -112,7 +112,7 @@ public class Utf8GetLengthBenchmark
         return count;
     }
 
-    //[Benchmark]
+    [Benchmark]
     public int GetLength_PopCount_SoftwareFallback()
     {
         var count = 0;
@@ -161,7 +161,7 @@ public class Utf8GetLengthBenchmark
         return count;
     }
 
-    //[Benchmark(Baseline = true)]
+    [Benchmark(Baseline = true)]
     public int GetLength_Avx2()
     {
         var count = 0;
@@ -261,86 +261,6 @@ public class Utf8GetLengthBenchmark
                     var vector = Vector256.LoadUnsafe(ref start, j);
                     sum = Avx2.Subtract(sum, Avx2.CompareGreaterThan(vector.AsSByte(), Vector256.Create<sbyte>(-0x41)).AsByte());
                 }
-
-                var sumHigh = Avx2.UnpackHigh(sum, Vector256<byte>.Zero);
-                var sumLow = Avx2.UnpackLow(sum, Vector256<byte>.Zero);
-                var sum16x16 = Avx2.Add(sumHigh.AsInt16(), sumLow.AsInt16());
-                var sum16x8 = Avx2.Add(sum16x16, Avx2.Permute2x128(sum16x16, sum16x16, 1));
-
-                const byte Control = (0 << 6) | (0 << 4) | (2 << 2) | 3;
-                var sum16x4 = Avx2.Add(sum16x8, Avx2.Shuffle(sum16x8.AsInt32(), Control).AsInt16());
-
-                var temp = sum16x4.AsInt64().GetElement(0);
-                count += (int)((temp >> 0) & 0xFFFF);
-                count += (int)((temp >> 16) & 0xFFFF);
-                count += (int)((temp >> 32) & 0xFFFF);
-                count += (int)((temp >> 48) & 0xFFFF);
-
-                i += j;
-            }
-            while (i < length32);
-
-            start = ref Unsafe.AddByteOffset(ref start, i);
-        }
-
-        if (Unsafe.ByteOffset(ref start, ref end) >= sizeof(ulong))
-        {
-            end = ref Unsafe.SubtractByteOffset(ref end, sizeof(ulong));
-
-            do
-            {
-                var number = Unsafe.ReadUnaligned<ulong>(ref start);
-
-                const ulong Mask = 0x8080808080808080 >> 7;
-                var x = ((number >> 6) | (~number >> 7)) & Mask;
-
-                count += BitOperations.PopCount(x);
-                start = ref Unsafe.AddByteOffset(ref start, sizeof(ulong));
-            }
-            while (!Unsafe.IsAddressGreaterThan(ref start, ref end));
-
-            end = ref Unsafe.AddByteOffset(ref end, sizeof(ulong));
-        }
-
-        while (Unsafe.IsAddressLessThan(ref start, ref end))
-        {
-            if ((start & 0xC0) != 0x80)
-            {
-                count++;
-            }
-
-            start = ref Unsafe.AddByteOffset(ref start, 1);
-        }
-
-        return count;
-    }
-
-    [Benchmark]
-    public int GetLength_Avx2_3()
-    {
-        var count = 0;
-
-        ref var start = ref MemoryMarshal.GetArrayDataReference(_value);
-        ref var end = ref Unsafe.AddByteOffset(ref start, (nint)(uint)_value.Length);
-
-        if (_value.Length >= Vector256<byte>.Count)
-        {
-            nuint i = 0;
-            var length32 = (nuint)(_value.Length & -Vector256<byte>.Count);
-
-            do
-            {
-                var sum = Vector256<byte>.Zero;
-                var limit = Math.Min((nuint)(255 * Vector256<byte>.Count), length32 - i);
-                nuint j = 0;
-
-                do
-                {
-                    var vector = Vector256.LoadUnsafe(ref start, j);
-                    sum = Avx2.Subtract(sum, Avx2.CompareGreaterThan(vector.AsSByte(), Vector256.Create<sbyte>(-0x41)).AsByte());
-                    j += (nuint)Vector256<byte>.Count;
-                }
-                while (j < limit);
 
                 var sumHigh = Avx2.UnpackHigh(sum, Vector256<byte>.Zero);
                 var sumLow = Avx2.UnpackLow(sum, Vector256<byte>.Zero);

--- a/Source/Utf8Utility.Benchmarks/Utf8GetLengthBenchmark.cs
+++ b/Source/Utf8Utility.Benchmarks/Utf8GetLengthBenchmark.cs
@@ -412,12 +412,13 @@ public class Utf8GetLengthBenchmark
 
         if (_value.Length >= Vector256<byte>.Count)
         {
+            ref var e = ref Unsafe.AddByteOffset(ref start, (nint)(uint)_value.Length);
             end = ref Unsafe.SubtractByteOffset(ref end, Vector256<byte>.Count);
 
             do
             {
                 var sum = Vector256<byte>.Zero;
-                var end2 = Math.Min(255 * 32, Unsafe.ByteOffset(ref start, ref end));
+                var end2 = Math.Min(255 * 32, Unsafe.ByteOffset(ref start, ref e) / 32 * 32);
                 var i = 0;
 
                 do

--- a/Source/Utf8Utility.Benchmarks/Utf8GetLengthBenchmark.cs
+++ b/Source/Utf8Utility.Benchmarks/Utf8GetLengthBenchmark.cs
@@ -17,7 +17,7 @@ public class Utf8GetLengthBenchmark
     [Params("a")]
     public string? Value { get; set; }
 
-    [Params(/*10, 63, 64, 95, 96,*/ 10000)]
+    [Params(10, 63, 64, 95, 96, 1000, 10000, 100000, 10000000)]
     public int Count { get; set; }
 
     [GlobalSetup]
@@ -33,7 +33,7 @@ public class Utf8GetLengthBenchmark
         _value = Encoding.UTF8.GetBytes(builder.ToString());
     }
 
-    //[Benchmark]
+    [Benchmark]
     public int GetLength_Table()
     {
         var count = 0;
@@ -52,7 +52,7 @@ public class Utf8GetLengthBenchmark
         return count;
     }
 
-    //[Benchmark]
+    [Benchmark]
     public int GetLength_Byte()
     {
         var count = 0;
@@ -73,7 +73,7 @@ public class Utf8GetLengthBenchmark
         return count;
     }
 
-    //[Benchmark]
+    [Benchmark]
     public int GetLength_PopCount()
     {
         var count = 0;
@@ -112,7 +112,7 @@ public class Utf8GetLengthBenchmark
         return count;
     }
 
-    //[Benchmark]
+    [Benchmark]
     public int GetLength_PopCount_SoftwareFallback()
     {
         var count = 0;
@@ -195,10 +195,10 @@ public class Utf8GetLengthBenchmark
                 var sum16x4 = Avx2.Add(sum16x8, Avx2.Shuffle(sum16x8.AsInt32(), Control).AsInt16());
 
                 var temp = sum16x4.AsInt64().GetElement(0);
-                count += (int)((temp >> 0) & 0xffff);
-                count += (int)((temp >> 16) & 0xffff);
-                count += (int)((temp >> 32) & 0xffff);
-                count += (int)((temp >> 48) & 0xffff);
+                count += (int)((temp >> 0) & 0xFFFF);
+                count += (int)((temp >> 16) & 0xFFFF);
+                count += (int)((temp >> 32) & 0xFFFF);
+                count += (int)((temp >> 48) & 0xFFFF);
             }
             while (!Unsafe.IsAddressGreaterThan(ref start, ref end));
 
@@ -247,173 +247,6 @@ public class Utf8GetLengthBenchmark
 
         if (_value.Length >= Vector256<byte>.Count)
         {
-            end = ref Unsafe.SubtractByteOffset(ref end, Vector256<byte>.Count);
-            var i = 0;
-            var l = _value.Length / 32 * 32;
-
-            do
-            {
-                var sum = Vector256<byte>.Zero;
-                //ref var end2 = ref Unsafe.AddByteOffset(ref start, Math.Min(255 * 32, Unsafe.ByteOffset(ref start, ref end)));
-                var limit = Math.Min(255 * 32, l - i);
-                var j = 0;
-
-                for (; j < limit; j += 32)
-                {
-                    var s = Vector256.LoadUnsafe(ref start, (nuint)(j));
-                    sum = Avx2.Subtract(sum, Avx2.CompareGreaterThan(s.AsSByte(), Vector256.Create<sbyte>(-0x41)).AsByte());
-
-                }
-
-                var sumHigh = Avx2.UnpackHigh(sum, Vector256<byte>.Zero);
-                var sumLow = Avx2.UnpackLow(sum, Vector256<byte>.Zero);
-                var sum16x16 = Avx2.Add(sumHigh.AsInt16(), sumLow.AsInt16());
-                var sum16x8 = Avx2.Add(sum16x16, Avx2.Permute2x128(sum16x16, sum16x16, 1));
-
-                const byte Control = (0 << 6) | (0 << 4) | (2 << 2) | 3;
-                var sum16x4 = Avx2.Add(sum16x8, Avx2.Shuffle(sum16x8.AsInt32(), Control).AsInt16());
-
-                var temp = sum16x4.AsInt64().GetElement(0);
-                count += (int)((temp >> 0) & 0xffff);
-                count += (int)((temp >> 16) & 0xffff);
-                count += (int)((temp >> 32) & 0xffff);
-                count += (int)((temp >> 48) & 0xffff);
-
-                i += j;
-                start = ref Unsafe.AddByteOffset(ref start, (nint)(uint)j);
-            }
-            while (!Unsafe.IsAddressGreaterThan(ref start, ref end));
-
-
-            end = ref Unsafe.AddByteOffset(ref end, Vector256<byte>.Count);
-        }
-
-        if (Unsafe.ByteOffset(ref start, ref end) >= sizeof(ulong))
-        {
-            end = ref Unsafe.SubtractByteOffset(ref end, sizeof(ulong));
-
-            do
-            {
-                var number = Unsafe.ReadUnaligned<ulong>(ref start);
-
-                const ulong Mask = 0x8080808080808080 >> 7;
-                var x = ((number >> 6) | (~number >> 7)) & Mask;
-
-                count += BitOperations.PopCount(x);
-                start = ref Unsafe.AddByteOffset(ref start, sizeof(ulong));
-            }
-            while (!Unsafe.IsAddressGreaterThan(ref start, ref end));
-
-            end = ref Unsafe.AddByteOffset(ref end, sizeof(ulong));
-        }
-
-        while (Unsafe.IsAddressLessThan(ref start, ref end))
-        {
-            if ((start & 0xC0) != 0x80)
-            {
-                count++;
-            }
-
-            start = ref Unsafe.AddByteOffset(ref start, 1);
-        }
-
-        return count;
-    }
-
-    [Benchmark]
-    public int GetLength_Avx2_3()
-    {
-        var count = 0;
-
-        ref var start = ref MemoryMarshal.GetArrayDataReference(_value);
-        ref var end = ref Unsafe.AddByteOffset(ref start, (nint)(uint)_value.Length);
-
-        if (_value.Length >= Vector256<byte>.Count)
-        {
-            end = ref Unsafe.SubtractByteOffset(ref end, Vector256<byte>.Count);
-            var i = 0;
-            var l = _value.Length / 32 * 32;
-
-            for (; i < l;)
-            {
-                var sum = Vector256<byte>.Zero;
-                //ref var end2 = ref Unsafe.AddByteOffset(ref start, Math.Min(255 * 32, Unsafe.ByteOffset(ref start, ref end)));
-                var limit = Math.Min(255 * 32, l - i);
-                var j = 0;
-
-                for (; j < limit; j += 32)
-                {
-                    var s = Vector256.LoadUnsafe(ref start, (nuint)(i + j));
-                    sum = Avx2.Subtract(sum, Avx2.CompareGreaterThan(s.AsSByte(), Vector256.Create<sbyte>(-0x41)).AsByte());
-
-                }
-
-                var sumHigh = Avx2.UnpackHigh(sum, Vector256<byte>.Zero);
-                var sumLow = Avx2.UnpackLow(sum, Vector256<byte>.Zero);
-                var sum16x16 = Avx2.Add(sumHigh.AsInt16(), sumLow.AsInt16());
-                var sum16x8 = Avx2.Add(sum16x16, Avx2.Permute2x128(sum16x16, sum16x16, 1));
-
-                const byte Control = (0 << 6) | (0 << 4) | (2 << 2) | 3;
-                var sum16x4 = Avx2.Add(sum16x8, Avx2.Shuffle(sum16x8.AsInt32(), Control).AsInt16());
-
-                var temp = sum16x4.AsInt64().GetElement(0);
-                count += (int)((temp >> 0) & 0xffff);
-                count += (int)((temp >> 16) & 0xffff);
-                count += (int)((temp >> 32) & 0xffff);
-                count += (int)((temp >> 48) & 0xffff);
-
-                i += j;
-
-            }
-
-            start = ref Unsafe.AddByteOffset(ref start, (nint)(uint)i);
-            end = ref Unsafe.AddByteOffset(ref end, Vector256<byte>.Count);
-        }
-
-        if (Unsafe.ByteOffset(ref start, ref end) >= sizeof(ulong))
-        {
-            end = ref Unsafe.SubtractByteOffset(ref end, sizeof(ulong));
-
-            do
-            {
-                var number = Unsafe.ReadUnaligned<ulong>(ref start);
-
-                const ulong Mask = 0x8080808080808080 >> 7;
-                var x = ((number >> 6) | (~number >> 7)) & Mask;
-
-                count += BitOperations.PopCount(x);
-                start = ref Unsafe.AddByteOffset(ref start, sizeof(ulong));
-            }
-            while (!Unsafe.IsAddressGreaterThan(ref start, ref end));
-
-            end = ref Unsafe.AddByteOffset(ref end, sizeof(ulong));
-        }
-
-        while (Unsafe.IsAddressLessThan(ref start, ref end))
-        {
-            if ((start & 0xC0) != 0x80)
-            {
-                count++;
-            }
-
-            start = ref Unsafe.AddByteOffset(ref start, 1);
-        }
-
-        return count;
-    }
-
-    [Benchmark]
-    public int GetLength_Avx2_4()
-    {
-        var count = 0;
-
-        ref var start = ref MemoryMarshal.GetArrayDataReference(_value);
-        ref var end = ref Unsafe.AddByteOffset(ref start, (nint)(uint)_value.Length);
-
-        if (_value.Length >= Vector256<byte>.Count)
-        {
-            end = ref Unsafe.SubtractByteOffset(ref end, Vector256<byte>.Count);
-
             nuint i = 0;
             var length32 = (nuint)(_value.Length & -Vector256<byte>.Count);
 
@@ -438,90 +271,10 @@ public class Utf8GetLengthBenchmark
                 var sum16x4 = Avx2.Add(sum16x8, Avx2.Shuffle(sum16x8.AsInt32(), Control).AsInt16());
 
                 var temp = sum16x4.AsInt64().GetElement(0);
-                count += (int)((temp >> 0) & 0xffff);
-                count += (int)((temp >> 16) & 0xffff);
-                count += (int)((temp >> 32) & 0xffff);
-                count += (int)((temp >> 48) & 0xffff);
-
-                i += j;
-                start = ref Unsafe.AddByteOffset(ref start, j);
-            }
-            while (!Unsafe.IsAddressGreaterThan(ref start, ref end));
-
-
-            end = ref Unsafe.AddByteOffset(ref end, Vector256<byte>.Count);
-        }
-
-        if (Unsafe.ByteOffset(ref start, ref end) >= sizeof(ulong))
-        {
-            end = ref Unsafe.SubtractByteOffset(ref end, sizeof(ulong));
-
-            do
-            {
-                var number = Unsafe.ReadUnaligned<ulong>(ref start);
-
-                const ulong Mask = 0x8080808080808080 >> 7;
-                var x = ((number >> 6) | (~number >> 7)) & Mask;
-
-                count += BitOperations.PopCount(x);
-                start = ref Unsafe.AddByteOffset(ref start, sizeof(ulong));
-            }
-            while (!Unsafe.IsAddressGreaterThan(ref start, ref end));
-
-            end = ref Unsafe.AddByteOffset(ref end, sizeof(ulong));
-        }
-
-        while (Unsafe.IsAddressLessThan(ref start, ref end))
-        {
-            if ((start & 0xC0) != 0x80)
-            {
-                count++;
-            }
-
-            start = ref Unsafe.AddByteOffset(ref start, 1);
-        }
-
-        return count;
-    }
-
-    [Benchmark]
-    public int GetLength_Avx2_5()
-    {
-        var count = 0;
-
-        ref var start = ref MemoryMarshal.GetArrayDataReference(_value);
-        ref var end = ref Unsafe.AddByteOffset(ref start, (nint)(uint)_value.Length);
-
-        if (_value.Length >= Vector256<byte>.Count)
-        {
-            nuint i = 0;
-            var length32 = (nuint)(_value.Length & -Vector256<byte>.Count);
-
-            do
-            {
-                var sum = Vector256<byte>.Zero;
-                var limit = Math.Min((nuint)(255 * Vector256<byte>.Count), length32 - i);
-                nuint j = 0;
-
-                for (; j < limit; j += (nuint)Vector256<byte>.Count)
-                {
-                    var vector = Vector256.LoadUnsafe(ref start, j);
-                    sum = Avx2.Subtract(sum, Avx2.CompareGreaterThan(vector.AsSByte(), Vector256.Create<sbyte>(-0x41)).AsByte());
-                }
-
-                var sumHigh = Avx2.UnpackHigh(sum, Vector256<byte>.Zero);
-                var sumLow = Avx2.UnpackLow(sum, Vector256<byte>.Zero);
-                var sum16x16 = Avx2.Add(sumHigh.AsInt16(), sumLow.AsInt16());
-                var sum16x8 = Avx2.Add(sum16x16, Avx2.Permute2x128(sum16x16, sum16x16, 1));
-
-                const byte Control = (0 << 6) | (0 << 4) | (2 << 2) | 3;
-                var sum16x4 = Avx2.Add(sum16x8, Avx2.Shuffle(sum16x8.AsInt32(), Control).AsInt16());
-
-                var temp = sum16x4.AsInt64().GetElement(0);
-                count += (int)((temp >> 0) & 0xffff);
-                count += (int)((temp >> 16) & 0xffff);
-                count += (int)((temp >> 32) & 0xffff);
-                count += (int)((temp >> 48) & 0xffff);
+                count += (int)((temp >> 0) & 0xFFFF);
+                count += (int)((temp >> 16) & 0xFFFF);
+                count += (int)((temp >> 32) & 0xFFFF);
+                count += (int)((temp >> 48) & 0xFFFF);
 
                 i += j;
             }

--- a/Source/Utf8Utility.Benchmarks/Utf8GetLengthBenchmark.cs
+++ b/Source/Utf8Utility.Benchmarks/Utf8GetLengthBenchmark.cs
@@ -249,12 +249,13 @@ public class Utf8GetLengthBenchmark
         {
             end = ref Unsafe.SubtractByteOffset(ref end, Vector256<byte>.Count);
             var i = 0;
+            var l = _value.Length / 32 * 32;
 
             do
             {
                 var sum = Vector256<byte>.Zero;
                 //ref var end2 = ref Unsafe.AddByteOffset(ref start, Math.Min(255 * 32, Unsafe.ByteOffset(ref start, ref end)));
-                var limit = Math.Min(255 * 32, _value.Length / 32 * 32 - i);
+                var limit = Math.Min(255 * 32, l - i);
                 var j = 0;
 
                 for (; j < limit; j += 32)
@@ -366,6 +367,86 @@ public class Utf8GetLengthBenchmark
             }
 
             start = ref Unsafe.AddByteOffset(ref start, (nint)(uint)i);
+            end = ref Unsafe.AddByteOffset(ref end, Vector256<byte>.Count);
+        }
+
+        if (Unsafe.ByteOffset(ref start, ref end) >= sizeof(ulong))
+        {
+            end = ref Unsafe.SubtractByteOffset(ref end, sizeof(ulong));
+
+            do
+            {
+                var number = Unsafe.ReadUnaligned<ulong>(ref start);
+
+                const ulong Mask = 0x8080808080808080 >> 7;
+                var x = ((number >> 6) | (~number >> 7)) & Mask;
+
+                count += BitOperations.PopCount(x);
+                start = ref Unsafe.AddByteOffset(ref start, sizeof(ulong));
+            }
+            while (!Unsafe.IsAddressGreaterThan(ref start, ref end));
+
+            end = ref Unsafe.AddByteOffset(ref end, sizeof(ulong));
+        }
+
+        while (Unsafe.IsAddressLessThan(ref start, ref end))
+        {
+            if ((start & 0xC0) != 0x80)
+            {
+                count++;
+            }
+
+            start = ref Unsafe.AddByteOffset(ref start, 1);
+        }
+
+        return count;
+    }
+
+    [Benchmark()]
+    public int GetLength_Avx2_4()
+    {
+        var count = 0;
+
+        ref var start = ref MemoryMarshal.GetArrayDataReference(_value);
+        ref var end = ref Unsafe.AddByteOffset(ref start, (nint)(uint)_value.Length);
+
+        if (_value.Length >= Vector256<byte>.Count)
+        {
+            end = ref Unsafe.SubtractByteOffset(ref end, Vector256<byte>.Count);
+
+            do
+            {
+                var sum = Vector256<byte>.Zero;
+                var end2 = Math.Min(255 * 32, Unsafe.ByteOffset(ref start, ref end));
+                var i = 0;
+
+                do
+                {
+                    var s = Vector256.LoadUnsafe(ref start, (nuint)i);
+                    sum = Avx2.Subtract(sum, Avx2.CompareGreaterThan(s.AsSByte(), Vector256.Create<sbyte>(-0x41)).AsByte());
+                    i += 32;
+                }
+                while (i < end2);
+
+                var sumHigh = Avx2.UnpackHigh(sum, Vector256<byte>.Zero);
+                var sumLow = Avx2.UnpackLow(sum, Vector256<byte>.Zero);
+                var sum16x16 = Avx2.Add(sumHigh.AsInt16(), sumLow.AsInt16());
+                var sum16x8 = Avx2.Add(sum16x16, Avx2.Permute2x128(sum16x16, sum16x16, 1));
+
+                const byte Control = (0 << 6) | (0 << 4) | (2 << 2) | 3;
+                var sum16x4 = Avx2.Add(sum16x8, Avx2.Shuffle(sum16x8.AsInt32(), Control).AsInt16());
+
+                var temp = sum16x4.AsInt64().GetElement(0);
+                count += (int)((temp >> 0) & 0xffff);
+                count += (int)((temp >> 16) & 0xffff);
+                count += (int)((temp >> 32) & 0xffff);
+                count += (int)((temp >> 48) & 0xffff);
+
+                start = ref Unsafe.AddByteOffset(ref start, (nint)(uint)i);
+            }
+            while (!Unsafe.IsAddressGreaterThan(ref start, ref end));
+
+
             end = ref Unsafe.AddByteOffset(ref end, Vector256<byte>.Count);
         }
 

--- a/Source/Utf8Utility/Helpers/BitOperations.cs
+++ b/Source/Utf8Utility/Helpers/BitOperations.cs
@@ -8,6 +8,36 @@ namespace Utf8Utility.Helpers;
 static class BitOperations
 {
     /// <summary>
+    /// 1になっているビットの数を取得します。
+    /// </summary>
+    /// <param name="value">値</param>
+    /// <returns>1になっているビットの数を返します。</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int PopCount(ulong value)
+#if NET7_0_OR_GREATER
+        => System.Numerics.BitOperations.PopCount(value);
+#else
+    {
+        return SoftwareFallback(value);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        static int SoftwareFallback(ulong value)
+        {
+            const ulong C1 = 0x_55555555_55555555;
+            const ulong C2 = 0x_33333333_33333333;
+            const ulong C3 = 0x_0F0F0F0F_0F0F0F0F;
+            const ulong C4 = 0x_01010101_01010101;
+
+            value -= (value >> 1) & C1;
+            value = (value & C2) + ((value >> 2) & C2);
+            value = (((value + (value >> 4)) & C3) * C4) >> 56;
+
+            return (int)value;
+        }
+    }
+#endif
+
+    /// <summary>
     /// 指定された数値を2の累乗になるように繰り上げます。
     /// </summary>
     /// <param name="value">数値</param>

--- a/Source/Utf8Utility/Text/UnicodeUtility.cs
+++ b/Source/Utf8Utility/Text/UnicodeUtility.cs
@@ -87,11 +87,13 @@ public static partial class UnicodeUtility
                 var limit = Math.Min((nuint)(255 * Vector256<byte>.Count), length32 - i);
                 nuint j = 0;
 
-                for (; j < limit; j += (nuint)Vector256<byte>.Count)
+                do
                 {
                     var vector = Vector256.LoadUnsafe(ref start, j);
                     sum = Avx2.Subtract(sum, Avx2.CompareGreaterThan(vector.AsSByte(), Vector256.Create<sbyte>(-0x41)).AsByte());
+                    j += (nuint)Vector256<byte>.Count;
                 }
+                while (j < limit);
 
                 var sumHigh = Avx2.UnpackHigh(sum, Vector256<byte>.Zero);
                 var sumLow = Avx2.UnpackLow(sum, Vector256<byte>.Zero);

--- a/Source/Utf8Utility/Text/UnicodeUtility.cs
+++ b/Source/Utf8Utility/Text/UnicodeUtility.cs
@@ -91,7 +91,7 @@ public static partial class UnicodeUtility
                     sum = Avx2.Subtract(sum, Avx2.CompareGreaterThan(s.AsSByte(), Vector256.Create<sbyte>(-0x41)).AsByte());
                     start = ref Unsafe.AddByteOffset(ref start, Vector256<byte>.Count);
                 }
-                while (!Unsafe.IsAddressGreaterThan(ref start, ref end2));
+                while (Unsafe.IsAddressLessThan(ref start, ref end2));
 
                 var sumHigh = Avx2.UnpackHigh(sum, Vector256<byte>.Zero);
                 var sumLow = Avx2.UnpackLow(sum, Vector256<byte>.Zero);

--- a/Tests/Utf8Utility.Tests/Text/UnicodeUtilityGetLengthTest.cs
+++ b/Tests/Utf8Utility.Tests/Text/UnicodeUtilityGetLengthTest.cs
@@ -39,10 +39,14 @@ public sealed class UnicodeUtilityGetLengthTest
     [Theory]
     [InlineData((255 * 32) - 1)]
     [InlineData(255 * 32)]
+    [InlineData(((255 - 1) * 32) - 1)]
+    [InlineData((255 - 1) * 32)]
+    [InlineData(((255 - 1) * 32) + 1)]
     [InlineData((255 * 32) + 1)]
     [InlineData(((255 + 1) * 32) - 1)]
     [InlineData((255 + 1) * 32)]
     [InlineData(((255 + 1) * 32) + 1)]
+    [InlineData(5000)]
     [InlineData(10000)]
     public void 長い文字列_長さを返す(int length)
     {

--- a/Tests/Utf8Utility.Tests/Text/UnicodeUtilityGetLengthTest.cs
+++ b/Tests/Utf8Utility.Tests/Text/UnicodeUtilityGetLengthTest.cs
@@ -21,8 +21,32 @@ public sealed class UnicodeUtilityGetLengthTest
     [InlineData("aα")]
     [InlineData("aあ")]
     [InlineData("a𩸽")]
+    [InlineData("0123456789012345678901234567890")]
+    [InlineData("01234567890123456789012345678901")]
+    [InlineData("012345678901234567890123456789012")]
+    [InlineData("012345678901234567890123456789010123456789012345678901234567890")]
+    [InlineData("0123456789012345678901234567890101234567890123456789012345678901")]
+    [InlineData("01234567890123456789012345678901012345678901234567890123456789012")]
+    [InlineData("𩸽😀🖳𩸽😀🖳𩸽😀🖳𩸽😀🖳𩸽😀🖳𩸽😀🖳𩸽😀🖳𩸽😀🖳𩸽😀🖳𩸽😀🖳𩸽😀🖳𩸽😀🖳𩸽😀🖳𩸽😀🖳")]
     public void 文字列_長さを返す(string value)
     {
+        var utf8 = Encoding.UTF8.GetBytes(value);
+        var info = new StringInfo(value);
+
+        UnicodeUtility.GetLength(utf8).Should().Be(info.LengthInTextElements);
+    }
+
+    [Theory]
+    [InlineData((255 * 32) - 1)]
+    [InlineData(255 * 32)]
+    [InlineData((255 * 32) + 1)]
+    [InlineData(((255 + 1) * 32) - 1)]
+    [InlineData((255 + 1) * 32)]
+    [InlineData(((255 + 1) * 32) + 1)]
+    [InlineData(10000)]
+    public void 長い文字列_長さを返す(int length)
+    {
+        var value = new string('a', length);
         var utf8 = Encoding.UTF8.GetBytes(value);
         var info = new StringInfo(value);
 

--- a/Tests/Utf8Utility.Tests/Utf8ArrayGetLengthTest.cs
+++ b/Tests/Utf8Utility.Tests/Utf8ArrayGetLengthTest.cs
@@ -19,8 +19,32 @@ public sealed class Utf8ArrayGetLengthTest
     [InlineData("aα")]
     [InlineData("aあ")]
     [InlineData("a𩸽")]
+    [InlineData("0123456789012345678901234567890")]
+    [InlineData("01234567890123456789012345678901")]
+    [InlineData("012345678901234567890123456789012")]
+    [InlineData("012345678901234567890123456789010123456789012345678901234567890")]
+    [InlineData("0123456789012345678901234567890101234567890123456789012345678901")]
+    [InlineData("01234567890123456789012345678901012345678901234567890123456789012")]
+    [InlineData("𩸽😀🖳𩸽😀🖳𩸽😀🖳𩸽😀🖳𩸽😀🖳𩸽😀🖳𩸽😀🖳𩸽😀🖳𩸽😀🖳𩸽😀🖳𩸽😀🖳𩸽😀🖳𩸽😀🖳𩸽😀🖳")]
     public void 文字列_長さを返す(string value)
     {
+        var array = new Utf8Array(value);
+        var info = new StringInfo(value);
+
+        array.GetLength().Should().Be(info.LengthInTextElements);
+    }
+
+    [Theory]
+    [InlineData((255 * 32) - 1)]
+    [InlineData(255 * 32)]
+    [InlineData((255 * 32) + 1)]
+    [InlineData(((255 + 1) * 32) - 1)]
+    [InlineData((255 + 1) * 32)]
+    [InlineData(((255 + 1) * 32) + 1)]
+    [InlineData(10000)]
+    public void 長い文字列_長さを返す(int length)
+    {
+        var value = new string('a', length);
         var array = new Utf8Array(value);
         var info = new StringInfo(value);
 

--- a/Tests/Utf8Utility.Tests/Utf8ArrayGetLengthTest.cs
+++ b/Tests/Utf8Utility.Tests/Utf8ArrayGetLengthTest.cs
@@ -37,10 +37,14 @@ public sealed class Utf8ArrayGetLengthTest
     [Theory]
     [InlineData((255 * 32) - 1)]
     [InlineData(255 * 32)]
+    [InlineData(((255 - 1) * 32) - 1)]
+    [InlineData((255 - 1) * 32)]
+    [InlineData(((255 - 1) * 32) + 1)]
     [InlineData((255 * 32) + 1)]
     [InlineData(((255 + 1) * 32) - 1)]
     [InlineData((255 + 1) * 32)]
     [InlineData(((255 + 1) * 32) + 1)]
+    [InlineData(5000)]
     [InlineData(10000)]
     public void 長い文字列_長さを返す(int length)
     {


### PR DESCRIPTION
fix #161 

```

BenchmarkDotNet v0.13.8, Windows 10 (10.0.19045.3324/22H2/2022Update)
AMD Ryzen 7 5800U with Radeon Graphics, 1 CPU, 16 logical and 8 physical cores
.NET SDK 8.0.100-preview.7.23376.3
  [Host]     : .NET 8.0.0 (8.0.23.37506), X64 RyuJIT AVX2
  Job-ABREFR : .NET 8.0.0 (8.0.23.37506), X64 RyuJIT AVX2

Runtime=.NET 8.0  

```
| Method                              | Value | Count    | Mean              | Error          | StdDev         | Median            | Ratio  | RatioSD | Allocated | Alloc Ratio |
|------------------------------------ |------ |--------- |------------------:|---------------:|---------------:|------------------:|-------:|--------:|----------:|------------:|
| **GetLength_Table**                     | **a**     | **10**       |          **5.946 ns** |      **0.0194 ns** |      **0.0172 ns** |          **5.943 ns** |   **4.08** |    **0.05** |         **-** |          **NA** |
| GetLength_Byte                      | a     | 10       |          3.089 ns |      0.0118 ns |      0.0111 ns |          3.085 ns |   2.12 |    0.03 |         - |          NA |
| GetLength_PopCount                  | a     | 10       |          1.368 ns |      0.0163 ns |      0.0153 ns |          1.359 ns |   0.94 |    0.01 |         - |          NA |
| GetLength_PopCount_SoftwareFallback | a     | 10       |          2.340 ns |      0.0166 ns |      0.0156 ns |          2.330 ns |   1.61 |    0.01 |         - |          NA |
| GetLength_Avx2                      | a     | 10       |          1.457 ns |      0.0171 ns |      0.0160 ns |          1.450 ns |   1.00 |    0.00 |         - |          NA |
| GetLength_Avx2_2                    | a     | 10       |          1.590 ns |      0.0239 ns |      0.0224 ns |          1.580 ns |   1.09 |    0.01 |         - |          NA |
|                                     |       |          |                   |                |                |                   |        |         |           |             |
| **GetLength_Table**                     | **a**     | **63**       |        **101.312 ns** |      **0.0465 ns** |      **0.0412 ns** |        **101.307 ns** |  **13.79** |    **0.06** |         **-** |          **NA** |
| GetLength_Byte                      | a     | 63       |         21.109 ns |      0.0497 ns |      0.0465 ns |         21.104 ns |   2.87 |    0.01 |         - |          NA |
| GetLength_PopCount                  | a     | 63       |          6.708 ns |      0.0355 ns |      0.0332 ns |          6.726 ns |   0.91 |    0.00 |         - |          NA |
| GetLength_PopCount_SoftwareFallback | a     | 63       |         14.157 ns |      0.0217 ns |      0.0203 ns |         14.153 ns |   1.93 |    0.01 |         - |          NA |
| GetLength_Avx2                      | a     | 63       |          7.350 ns |      0.0339 ns |      0.0317 ns |          7.364 ns |   1.00 |    0.00 |         - |          NA |
| GetLength_Avx2_2                    | a     | 63       |          6.643 ns |      0.0274 ns |      0.0243 ns |          6.645 ns |   0.90 |    0.00 |         - |          NA |
|                                     |       |          |                   |                |                |                   |        |         |           |             |
| **GetLength_Table**                     | **a**     | **64**       |        **103.796 ns** |      **0.0536 ns** |      **0.0501 ns** |        **103.791 ns** |  **30.62** |    **0.27** |         **-** |          **NA** |
| GetLength_Byte                      | a     | 64       |         21.688 ns |      0.0288 ns |      0.0241 ns |         21.694 ns |   6.39 |    0.06 |         - |          NA |
| GetLength_PopCount                  | a     | 64       |          4.969 ns |      0.0509 ns |      0.0476 ns |          4.981 ns |   1.47 |    0.01 |         - |          NA |
| GetLength_PopCount_SoftwareFallback | a     | 64       |         13.232 ns |      0.0192 ns |      0.0180 ns |         13.233 ns |   3.90 |    0.03 |         - |          NA |
| GetLength_Avx2                      | a     | 64       |          3.390 ns |      0.0321 ns |      0.0300 ns |          3.408 ns |   1.00 |    0.00 |         - |          NA |
| GetLength_Avx2_2                    | a     | 64       |          2.576 ns |      0.0245 ns |      0.0229 ns |          2.581 ns |   0.76 |    0.01 |         - |          NA |
|                                     |       |          |                   |                |                |                   |        |         |           |             |
| **GetLength_Table**                     | **a**     | **95**       |        **167.258 ns** |      **0.0493 ns** |      **0.0412 ns** |        **167.270 ns** |  **25.88** |    **0.18** |         **-** |          **NA** |
| GetLength_Byte                      | a     | 95       |         32.030 ns |      0.0400 ns |      0.0375 ns |         32.044 ns |   4.95 |    0.03 |         - |          NA |
| GetLength_PopCount                  | a     | 95       |          9.681 ns |      0.0392 ns |      0.0367 ns |          9.702 ns |   1.50 |    0.01 |         - |          NA |
| GetLength_PopCount_SoftwareFallback | a     | 95       |         21.160 ns |      0.0213 ns |      0.0200 ns |         21.165 ns |   3.27 |    0.02 |         - |          NA |
| GetLength_Avx2                      | a     | 95       |          6.467 ns |      0.0452 ns |      0.0423 ns |          6.487 ns |   1.00 |    0.00 |         - |          NA |
| GetLength_Avx2_2                    | a     | 95       |          6.631 ns |      0.0443 ns |      0.0393 ns |          6.637 ns |   1.03 |    0.00 |         - |          NA |
|                                     |       |          |                   |                |                |                   |        |         |           |             |
| **GetLength_Table**                     | **a**     | **96**       |        **169.249 ns** |      **0.1110 ns** |      **0.0984 ns** |        **169.254 ns** |  **47.35** |    **0.37** |         **-** |          **NA** |
| GetLength_Byte                      | a     | 96       |         31.966 ns |      0.0707 ns |      0.0661 ns |         31.965 ns |   8.94 |    0.07 |         - |          NA |
| GetLength_PopCount                  | a     | 96       |          7.687 ns |      0.0420 ns |      0.0393 ns |          7.672 ns |   2.15 |    0.02 |         - |          NA |
| GetLength_PopCount_SoftwareFallback | a     | 96       |         20.530 ns |      0.0817 ns |      0.0765 ns |         20.554 ns |   5.75 |    0.05 |         - |          NA |
| GetLength_Avx2                      | a     | 96       |          3.575 ns |      0.0350 ns |      0.0274 ns |          3.572 ns |   1.00 |    0.00 |         - |          NA |
| GetLength_Avx2_2                    | a     | 96       |          2.845 ns |      0.0259 ns |      0.0243 ns |          2.846 ns |   0.80 |    0.01 |         - |          NA |
|                                     |       |          |                   |                |                |                   |        |         |           |             |
| **GetLength_Table**                     | **a**     | **1000**     |      **2,032.660 ns** |      **0.0483 ns** |      **0.0377 ns** |      **2,032.669 ns** | **186.89** |    **0.57** |         **-** |          **NA** |
| GetLength_Byte                      | a     | 1000     |        345.936 ns |      0.4892 ns |      0.4576 ns |        346.134 ns |  31.82 |    0.10 |         - |          NA |
| GetLength_PopCount                  | a     | 1000     |         76.977 ns |      0.1456 ns |      0.1362 ns |         77.002 ns |   7.08 |    0.02 |         - |          NA |
| GetLength_PopCount_SoftwareFallback | a     | 1000     |        215.844 ns |      0.3156 ns |      0.2952 ns |        215.830 ns |  19.86 |    0.07 |         - |          NA |
| GetLength_Avx2                      | a     | 1000     |         10.869 ns |      0.0407 ns |      0.0361 ns |         10.875 ns |   1.00 |    0.00 |         - |          NA |
| GetLength_Avx2_2                    | a     | 1000     |         10.000 ns |      0.0311 ns |      0.0291 ns |          9.998 ns |   0.92 |    0.00 |         - |          NA |
|                                     |       |          |                   |                |                |                   |        |         |           |             |
| **GetLength_Table**                     | **a**     | **10000**    |     **20,281.500 ns** |      **0.8826 ns** |      **0.7371 ns** |     **20,281.622 ns** | **132.82** |    **0.41** |         **-** |          **NA** |
| GetLength_Byte                      | a     | 10000    |      3,416.393 ns |      6.2123 ns |      5.5070 ns |      3,416.605 ns |  22.38 |    0.09 |         - |          NA |
| GetLength_PopCount                  | a     | 10000    |        720.269 ns |      0.7494 ns |      0.7010 ns |        720.309 ns |   4.72 |    0.01 |         - |          NA |
| GetLength_PopCount_SoftwareFallback | a     | 10000    |      2,136.329 ns |      3.1554 ns |      2.9516 ns |      2,137.231 ns |  13.99 |    0.04 |         - |          NA |
| GetLength_Avx2                      | a     | 10000    |        152.656 ns |      0.4908 ns |      0.4591 ns |        152.723 ns |   1.00 |    0.00 |         - |          NA |
| GetLength_Avx2_2                    | a     | 10000    |         83.514 ns |      0.2917 ns |      0.2728 ns |         83.563 ns |   0.55 |    0.00 |         - |          NA |
|                                     |       |          |                   |                |                |                   |        |         |           |             |
| **GetLength_Table**                     | **a**     | **100000**   |    **202,808.383 ns** |     **18.3697 ns** |     **17.1830 ns** |    **202,799.695 ns** | **129.83** |    **0.43** |         **-** |          **NA** |
| GetLength_Byte                      | a     | 100000   |     34,086.846 ns |     67.7887 ns |     63.4096 ns |     34,117.773 ns |  21.82 |    0.07 |         - |          NA |
| GetLength_PopCount                  | a     | 100000   |      7,284.385 ns |     30.6715 ns |     28.6901 ns |      7,290.979 ns |   4.66 |    0.02 |         - |          NA |
| GetLength_PopCount_SoftwareFallback | a     | 100000   |     21,355.323 ns |     25.7552 ns |     22.8313 ns |     21,358.696 ns |  13.66 |    0.05 |         - |          NA |
| GetLength_Avx2                      | a     | 100000   |      1,562.170 ns |      5.4931 ns |      5.1382 ns |      1,561.364 ns |   1.00 |    0.00 |         - |          NA |
| GetLength_Avx2_2                    | a     | 100000   |        826.393 ns |      2.2979 ns |      2.1495 ns |        826.765 ns |   0.53 |    0.00 |         - |          NA |
|                                     |       |          |                   |                |                |                   |        |         |           |             |
| **GetLength_Table**                     | **a**     | **10000000** | **20,287,060.714 ns** |  **1,487.5812 ns** |  **1,318.7020 ns** | **20,287,040.625 ns** | **125.80** |   **19.18** |      **12 B** |          **NA** |
| GetLength_Byte                      | a     | 10000000 |  3,087,065.904 ns | 20,992.7191 ns | 18,609.4987 ns |  3,090,924.219 ns |  19.15 |    2.97 |       2 B |          NA |
| GetLength_PopCount                  | a     | 10000000 |    752,643.157 ns |  2,813.9789 ns |  2,349.7998 ns |    753,526.465 ns |   4.62 |    0.72 |         - |          NA |
| GetLength_PopCount_SoftwareFallback | a     | 10000000 |  2,146,100.167 ns |  4,273.0341 ns |  3,787.9334 ns |  2,145,345.312 ns |  13.31 |    2.03 |       2 B |          NA |
| GetLength_Avx2                      | a     | 10000000 |    159,107.624 ns |  7,073.0639 ns | 20,855.0884 ns |    152,557.361 ns |   1.00 |    0.00 |         - |          NA |
| GetLength_Avx2_2                    | a     | 10000000 |     81,713.859 ns |    241.2390 ns |    225.6551 ns |     81,708.478 ns |   0.51 |    0.07 |         - |          NA |
